### PR TITLE
bugfix/firefox-datagrid-filter

### DIFF
--- a/js/components/faceted-datatable.html
+++ b/js/components/faceted-datatable.html
@@ -4,7 +4,7 @@
 			<div data-bind="foreach:Facets">
 				<div class="facetName"><i class="fa fa-filter"></i><span data-bind="text:caption"></span></div>
 				<div class="facetScrollBox" data-bind="foreach:Members">
-					<div class="facetMemberName" data-bind="click: function() { $component.updateFilters();}, css : {selected: Selected}">
+					<div class="facetMemberName" data-bind="click: function(data, event) { $component.updateFilters($data, event);}, css : {selected: Selected}">
 						<span data-bind="attr: {id: $parentContext.$index() + '-' + $index()}, text:Name + ' (' + ActiveCount + ')'"></span>
 					</div>
 				</div>

--- a/js/components/faceted-datatable.js
+++ b/js/components/faceted-datatable.js
@@ -17,7 +17,7 @@ define(['knockout', 'text!./faceted-datatable.html', 'facets', 'knockout.dataTab
 		self.data = ko.observableArray();
 		self.facetEngine = ko.observable();
 
-		self.updateFilters = function () {
+		self.updateFilters = function (data, event) {
 			$(event.target).closest('.facetMemberName').toggleClass('selected');
 
 			var filters = [];


### PR DESCRIPTION
Fixes an issue with the Faceted Data Table component filter not working in Firefox.
* Tested on Firefox edge version on OSX (Would be good to confirm on windows just in case)
* In the event that this issue is still present elsewhere in the app, the root cause relates to this knockout.js issue: #752 https://github.com/knockout/knockout/issues/752