### PR TITLE
fix resource URLs to work with http or https

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,7 +223,7 @@
 		</div>
 	</div>
 	<script data-main="js/main" src="js/require.js"></script>
-	<script type="text/javascript" charset="utf-8" src="http://animate.adobe.com/runtime/5.0.1/edge.5.0.1.min.js"></script>
+	<script type="text/javascript" charset="utf-8" src="//animate.adobe.com/runtime/5.0.1/edge.5.0.1.min.js"></script>
 	<script>
 		AdobeEdge.loadComposition('atlas%20animation', 'EDGE-8182598', {
 			scaleToFit: "none",

--- a/js/main.js
+++ b/js/main.js
@@ -23,8 +23,8 @@ requirejs.config({
 		}
 	},
 	paths: {
-		"jquery": "http://code.jquery.com/jquery-1.11.2.min",
-		"bootstrap": "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min",
+		"jquery": "//code.jquery.com/jquery-1.11.2.min",
+		"bootstrap": "//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min",
 		"text": "plugins/text",
 		"knockout": "knockout.min",
 		"knockout-mapping": "knockout.mapping",


### PR DESCRIPTION
We were having issues running Atlas on HTTPS. This works for me local (http) or on our server (https).

Thanks.