### PR TITLE
Fixes #215 and adds further granularity for parent/child by vocabulary

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -565,6 +565,16 @@ define(['jquery', 'knockout', 'jnj_chart', 'd3', 'ohdsi.util', 'appConfig', 'fac
             }]
 		};
 		self.metatrix = {
+            'ATC.ATC 4th': {                
+				childRelationships: [{
+					name: 'Has descendant of',
+					range: [0, 1]
+                }],
+				parentRelationships: [{
+					name: 'Has ancestor of',
+					range: [0, 5]
+                }]
+            },
 			'ICD9CM.5-dig billing code': {
 				childRelationships: [{
 					name: 'Subsumes',
@@ -604,8 +614,9 @@ define(['jquery', 'knockout', 'jnj_chart', 'd3', 'ohdsi.util', 'appConfig', 'fac
 					range: [0, 999]
                 }],
 				parentRelationships: [{
-					name: 'Has inferred drug class (OMOP)',
-					range: [0, 999]
+                    name: 'Has ancestor of',
+                    vocabulary: ['ATC', 'ETC'],
+                    range: [0, 1]
                 }]
 			},
 			'RxNorm.Brand Name': {
@@ -750,7 +761,15 @@ define(['jquery', 'knockout', 'jnj_chart', 'd3', 'ohdsi.util', 'appConfig', 'fac
 				for (var i = 0; i < relationships.length; i++) {
 					if (concept.RELATIONSHIPS[r].RELATIONSHIP_NAME == relationships[i].name) {
 						if (concept.RELATIONSHIPS[r].RELATIONSHIP_DISTANCE >= relationships[i].range[0] && concept.RELATIONSHIPS[r].RELATIONSHIP_DISTANCE <= relationships[i].range[1]) {
-							return true;
+                            if (relationships[i].vocabulary) {
+                                for(var v = 0; v < relationships[i].vocabulary.length; v++) {
+                                    if (relationships[i].vocabulary[v] == concept.VOCABULARY_ID) {
+                                        return true;
+                                    }
+                                }
+                            } else {
+                                return true;
+                            }
 						}
 					}
 				}


### PR DESCRIPTION
Adding in the ability to see parent/child relationships for ATC 4th and 5th concepts. Also extended the metatrix object to support an optional "vocabulary" property which allows you to specify an array of vocabularies to consider along with the concept relationship and range. This was added to provide the ability to show parent ETC and ATC ancestor concepts in the hierarchy view for a selected RxNorm Ingredient concept. The dependent function hasRelationship was modified to support this optional property.

@fdefalco - I'd like your feedback on the approach since your familiar with this functionality
@pbr6cornell  - Please provide your feedback around the hierarchy configuration I've specified. For RxNorm Ingredient concepts, we originally considered all parent concepts that had a relationship_name of "Has inferred drug class (OMOP)" - this relationship appears to be deprecated in the vocabulary. Now I've specified that for a given RxNorm Ingredient, we'll consider the following as "parent" concepts if they have one of these relationships:

RxNorm to ATC (RxNorm) (any level)
RxNorm to ETC (FDB) (any level)
Has ancestor of - 1st level and only concepts in the ATC and ETC vocabularies

For ATC 5th classes, children will be Rx Norm Ingredient(s) and the parent will be ATC 4th. 
For ATC 4th classes, children will be ATC 5th classes and RxNorm Ingredients and the parents will be ATC 1st-3rd.