### PR TITLE
Fixes #384.

### DIFF
--- a/js/components/cohort-definition-manager.html
+++ b/js/components/cohort-definition-manager.html
@@ -100,7 +100,7 @@
 					<div class="heading">
 						Name:
 					</div>
-						<div class="divtext" data-bind="attr: { contenteditable:canEdit() }, htmlValue:model.currentConceptSet().name"></div>
+						<div class="divtext" data-bind="attr: { disabled:!canEdit() }, contentEditable:model.currentConceptSet().name"></div>
 					<conceptset-editor params="model: model, conceptSets:selectedConcepts"></conceptset-editor>
 
 					<div class="clear"></div>

--- a/js/components/cohort-definition-manager.html
+++ b/js/components/cohort-definition-manager.html
@@ -100,7 +100,7 @@
 					<div class="heading">
 						Name:
 					</div>
-						<div class="divtext" data-bind="attr: { disabled:!canEdit() }, contentEditable:model.currentConceptSet().name"></div>
+						<div class="divtext" data-bind="attr: { contenteditable:canEdit() }, htmlValue:model.currentConceptSet().name"></div>
 					<conceptset-editor params="model: model, conceptSets:selectedConcepts"></conceptset-editor>
 
 					<div class="clear"></div>

--- a/js/modules/databindings/htmlValueBinding.js
+++ b/js/modules/databindings/htmlValueBinding.js
@@ -17,6 +17,9 @@ define(['knockout'], function (ko) {
 		update: function (element, valueAccessor, allBindingsAccessor) {
 			var value = ko.utils.unwrapObservable(valueAccessor());
 			var allBindings = allBindingsAccessor();
+			
+			if (element === document.activeElement) return; // element is active, so don't overwrite the html value
+			
 			if ((value == null || value.length == 0) && allBindings.defaultValue)
 				element.innerHTML = allBindings.defaultValue;
 			else


### PR DESCRIPTION
Use contenteditable databind instead of htmlValue.  Chrome 57 breaks the htmlValue binding.