### PR TITLE
Cohort Editor: Concept Set Preview

### DIFF
--- a/js/components/atlas.cohort-editor.html
+++ b/js/components/atlas.cohort-editor.html
@@ -12,7 +12,10 @@
 </div>
 
 <div class="paddedWrapper">
-	<div data-bind="eventListener: { event: 'click', selector: '.conceptset_selector', callback: handleConceptSetSelect}">
+	<div data-bind="eventListener: [
+									{ event: 'click', selector: '.conceptset_import', callback: handleConceptSetImport},
+									{ event: 'click', selector: '.conceptset_edit', callback: handleEditConceptSet}
+									]">
 		<!-- ko if:canEdit-->
 		<cohort-expression-editor params="expression: model.currentCohortDefinition().expression, widget: $component.cohortExpressionEditor"></cohort-expression-editor>
 		<!-- /ko -->
@@ -22,7 +25,7 @@
 		<div class="modal fade" id="conceptSetSelectorDialog" tabindex="-1" role="dialog">
 			<div class="modal-dialog modal-lg">
 				<div class="modal-content">
-					<div class="modal-header">Select Concept Set...</div>
+					<div class="modal-header">Import Concept Set From Repository...</div>
 					<div class="paddedWrapper">
 						<cohort-concept-set-browser params="criteriaContext: model.criteriaContext, cohortConceptSets: model.currentCohortDefinition().expression().ConceptSets, onActionComplete: onAtlasConceptSetSelectAction"></cohort-concept-set-browser>
 					</div>

--- a/js/components/atlas.cohort-editor.js
+++ b/js/components/atlas.cohort-editor.js
@@ -40,11 +40,21 @@ define(['knockout',
         
 		// model behaviors
 
-		self.handleConceptSetSelect = function (item) {
+		self.handleConceptSetImport = function (item, context) {
 			//alert(item);
-            self.model.criteriaContext(item);
-            $('#conceptSetSelectorDialog').modal('show');
+			self.model.criteriaContext(item);
+			$('#conceptSetSelectorDialog').modal('show');
 		}
+		
+		self.handleEditConceptSet = function(item, context) {
+			if (item.conceptSetId() == null) {
+				return;
+			}
+			
+			self.model.loadConceptSet(item.conceptSetId(), 'cohort-definition-manager', 'cohort', 'details');
+			self.model.currentCohortDefinitionMode("conceptsets");
+		}
+		
 
 		self.onAtlasConceptSetSelectAction = function(result, valueAccessor) {
 				$('#conceptSetSelectorDialog').modal('hide');

--- a/js/components/cohort-definition-manager.html
+++ b/js/components/cohort-definition-manager.html
@@ -72,7 +72,7 @@
 															{ data: 'name', title: 'Title', width: '100%' },
 													],
 													language: {
-															search: 'Filter Repository Concept Sets:'
+															search: 'Filter Cohort Concept Sets:'
 													}
 											}
 									 }">

--- a/js/components/conceptset-browser.html
+++ b/js/components/conceptset-browser.html
@@ -4,7 +4,7 @@
 <div class="clear">
 	<div class="paddedWrapper">
         <div data-bind="if:$component.mode() == 'add'">
-            <cohort-concept-set-browser params="criteriaContext: model.criteriaContext, cohortConceptSets: null, onRespositoryConceptSetSelected: $component.onRespositoryConceptSetSelected, onActionComplete: $component.onConceptSetBrowserAction, disableConceptSetButton: model.currentConceptSet() != undefined || !canCreateConceptSet()"></cohort-concept-set-browser>
+            <cohort-concept-set-browser params="criteriaContext: model.criteriaContext, onRespositoryConceptSetSelected: $component.onRespositoryConceptSetSelected, onActionComplete: $component.onConceptSetBrowserAction, disableConceptSetButton: model.currentConceptSet() != undefined || !canCreateConceptSet()"></cohort-concept-set-browser>
         </div>
         <div data-bind="if:$component.mode() == 'export'">
             <div class="heading">
@@ -12,7 +12,7 @@
             </div>
             <b>Instructions:</b>Select the concept sets for export by selecting each row in the grid. When done, use the 'Export Concept Sets' button which will start the download in a new window.
             <hr/>
-            <cohort-concept-set-browser params="criteriaContext: model.criteriaContext, cohortConceptSets: null, onRespositoryConceptSetSelected: $component.exportOnConceptSetSelected, onActionComplete: $component.onExportAction, buttonActionText: 'Export Concept Sets', repositoryConceptSetTableId: 'exportConceptSetTable'"></cohort-concept-set-browser>            
+            <cohort-concept-set-browser params="criteriaContext: model.criteriaContext, onRespositoryConceptSetSelected: $component.exportOnConceptSetSelected, onActionComplete: $component.onExportAction, buttonActionText: 'Export Concept Sets', repositoryConceptSetTableId: 'exportConceptSetTable'"></cohort-concept-set-browser>            
             <hr/>
             <b><span data-bind="text: $component.exportRowCount()"></span></b> concept sets selected for export.
         </div>

--- a/js/components/ir-manager.html
+++ b/js/components/ir-manager.html
@@ -41,7 +41,7 @@
 		</ul>
 		<div class="tab-content">
 			<div role="tabpanel" data-bind="css: { active: $component.activeTab() == 'definition' }" class="tab-pane">
-				<div data-bind="eventListener: { event: 'click', selector: '.conceptset_selector', callback: handleConceptSetSelect}">
+				<div data-bind="eventListener: { event: 'click', selector: '.conceptset_import', callback: handleConceptSetImport}">
 					<ir-analysis-editor params="analysis: selectedAnalysis().expression, analysisCohorts: analysisCohorts"></ir-analysis-editor>
 				</div>
 			</div>

--- a/js/components/ir-manager.js
+++ b/js/components/ir-manager.js
@@ -126,7 +126,7 @@ define(['knockout',
 			});
 		};
 		
-		self.handleConceptSetSelect = function (item) {
+		self.handleConceptSetImport = function (item) {
 			self.criteriaContext(item);
 			self.showConceptSetBrowser(true);
 		}

--- a/js/main.js
+++ b/js/main.js
@@ -46,8 +46,9 @@ requirejs.config({
 	},
 	map: {
 		"*": {
-			'jquery-ui/sortable': 'jquery-ui',
-			'jquery-ui/draggable': 'jquery-ui',
+			'jquery-ui/ui/widgets/sortable': 'jquery-ui',
+			'jquery-ui/ui/widgets/draggable': 'jquery-ui',
+			'jquery-ui/ui/widgets/droppable': 'jquery-ui',
 			'jquery-ui/dialog': 'jquery-ui',
 			'jquery-ui/autocomplete': 'jquery-ui',
 			'jquery-ui/tabs': 'jquery-ui'
@@ -64,7 +65,7 @@ requirejs.config({
 		"css": "plugins/css.min",
 		"clipboard": "clipboard.min",
 		"knockout": "knockout.min",
-		"ko.sortable": "https://cdnjs.cloudflare.com/ajax/libs/knockout-sortable/0.11.0/knockout-sortable",
+		"ko.sortable": "https://cdnjs.cloudflare.com/ajax/libs/knockout-sortable/1.1.0/knockout-sortable.min",
 		"knockout-mapping": "knockout.mapping",
 		"datatables.net": "jquery.dataTables.min",
 		"datatables.net-buttons": "jquery.dataTables.buttons.min",

--- a/js/modules/circe/components/CohortConceptSetBrowser.js
+++ b/js/modules/circe/components/CohortConceptSetBrowser.js
@@ -28,13 +28,6 @@ define(['knockout', 'text!./CohortConceptSetBrowserTemplate.html', 'vocabularypr
 				});
 		}
 
-		function defaultConceptSetSelected(conceptSet) {
-			self.criteriaContext() && self.criteriaContext().conceptSetId(conceptSet.id);
-			self.onActionComplete({
-				action: 'assign',
-				status: 'Success'
-			});
-		}
 
 		function setDisabledConceptSetButton(action) {
 			if (action && action()) {
@@ -48,7 +41,6 @@ define(['knockout', 'text!./CohortConceptSetBrowserTemplate.html', 'vocabularypr
 		self.cohortConceptSets = params.cohortConceptSets;
 		self.onActionComplete = params.onActionComplete;
 		self.onRespositoryConceptSetSelected = params.onRespositoryConceptSetSelected || defaultRepositoryConceptSetSelected;
-		self.onCohortConceptSetSelected = params.onCohortConceptSetSelected || defaultConceptSetSelected;
 		self.disableConceptSetButton = setDisabledConceptSetButton(params.disableConceptSetButton);
 		self.buttonActionText = params.buttonActionText || "New Concept Set";
 		self.repositoryConceptSetTableId = params.repositoryConceptSetTableId || "repositoryConceptSetTable";
@@ -61,6 +53,8 @@ define(['knockout', 'text!./CohortConceptSetBrowserTemplate.html', 'vocabularypr
 		appConfig.services.forEach(function (service) {
 			self.sources.push(service);
 		});
+
+		self.selectedSource = ko.observable(self.sources[0]);
 
 		self.loadConceptSetsFromRepository = function (url) {
 			self.loading(true);
@@ -75,29 +69,7 @@ define(['knockout', 'text!./CohortConceptSetBrowserTemplate.html', 'vocabularypr
 				});
 		}
 
-		// See if we can put this at the head and when it doesn't exist
-		// make sure we load the repository concept sets first.
-		if (self.cohortConceptSets != null) {
-			self.sources.unshift({
-				"name": "Cohort Definition",
-				"url": null
-			});
-		} else {
-			self.loadConceptSetsFromRepository(self.sources[0].url);
-		}
-
-		self.selectedSource = ko.observable(self.sources[0]);
-		self.sourceSubscription = self.selectedSource.subscribe(function (newSource) {
-			if (newSource.url != null) {
-				self.loadConceptSetsFromRepository(newSource.url)
-			}
-		});
-
 		// datatable callbacks:
-
-		self.selectCohortConceptSet = function (conceptSet) {
-			self.onCohortConceptSetSelected(conceptSet);
-		}
 
 		self.selectRepositoryConceptSet = function (conceptSet, valueAccessor) {
 			self.onRespositoryConceptSetSelected(conceptSet, valueAccessor);
@@ -111,9 +83,9 @@ define(['knockout', 'text!./CohortConceptSetBrowserTemplate.html', 'vocabularypr
 		}
 
 		// dispose subscriptions
-		self.dispose = function () {
-			self.sourceSubscription.dispose();
-		}
+		
+		// startup actions
+		self.loadConceptSetsFromRepository(self.selectedSource().url);
 	}
 
 	var component = {

--- a/js/modules/circe/components/CohortConceptSetBrowserTemplate.html
+++ b/js/modules/circe/components/CohortConceptSetBrowserTemplate.html
@@ -1,7 +1,6 @@
 <table width="width:100%" style="margin-bottom: 10px">
 	<tr>
 		<td width="100%" style="padding-right:15px">
-			<select class="form-control" data-bind="visible: $component.sources.length>1, enable: loading()==false, options:$component.sources, optionsText:'name', value:selectedSource"></select>
 		</td>
 		<td>
 			<div class="btn btn-sm btn-primary" style="width: 175px" data-bind="click: addConceptSet, css: {disabled: disableConceptSetButton}, text: buttonActionText"></div>
@@ -9,29 +8,6 @@
 	</tr>
 </table>
 
-<div data-bind="if:$component.selectedSource().url == null">
-	<div data-bind="visible:$component.selectedSource().url == null,
-                                    eventListener: [{event: 'click', selector: '.cohortConceptSetItem', callback: selectCohortConceptSet}]">
-		<table class="stripe compact hover" cellspacing="0" width="100%" data-bind="dataTable:{
-                data: cohortConceptSets(),
-                options: {
-                    deferRender: true,
-                    orderClasses: false,
-                    autoWidth: false,
-                    order: [ 1, 'asc' ],
-                    stripeClasses : [ 'cohortConceptSetItem' ],
-                    columns: [
-                        { data: 'id', title: 'Id', width: '25px'},
-                        { data: 'name', title: 'Title', width: '100%' },
-                    ],
-                    language: {
-                        search: 'Filter Cohort Concept Sets:'
-                    }
-                }, 
-             }">
-		</table>
-	</div>
-</div>
 <div data-bind="visible:$component.selectedSource().url != null,
 								eventListener: [{event: 'click', selector: '.repositoryConceptSetItem', callback: selectRepositoryConceptSet}]">
 	<!-- ko if: loading -->

--- a/js/modules/cohortbuilder/bindings/dropupBinding.js
+++ b/js/modules/cohortbuilder/bindings/dropupBinding.js
@@ -1,0 +1,22 @@
+define(['jquery', 'knockout'], function ($, ko) {
+	ko.bindingHandlers.dropup = {
+		init: function (element, valueAccessor, allBindingsAccessor) {
+			$(element).on("shown.bs.dropdown", function () {
+					// calculate the required sizes, spaces
+					var $ul = $(this).children(".dropdown-menu");
+					var $button = $(this).children(".dropdown-toggle");
+					var ulOffset = $ul.offset();http://jsfiddle.net/3s2efe9u/#
+					// how much space would be left on the top if the dropdown opened that direction
+					var spaceUp = (ulOffset.top - $button.height() - $ul.height()) - $(window).scrollTop();
+					// how much space is left at the bottom
+					var spaceDown = $(window).scrollTop() + $(window).height() - (ulOffset.top + $ul.height());
+					// switch to dropup only if there is no space at the bottom AND there is space at the top, or there isn't either but it would be still better fit
+					if (spaceDown < 0 && (spaceUp >= 0 || spaceUp > spaceDown))
+						$(this).addClass("dropup");
+			}).on("hidden.bs.dropdown", function() {
+					// always reset after close
+					$(this).removeClass("dropup");
+			});		
+		}
+	};
+});

--- a/js/modules/cohortbuilder/components.js
+++ b/js/modules/cohortbuilder/components.js
@@ -73,5 +73,8 @@ define(function (require, exports) {
 	
 	var endStrategyEditor = require('./components/EndStrategyEditor');
 	ko.components.register('end-strategy-editor', endStrategyEditor);
+
+	var conceptSetPreview = require('./components/ConceptSetQuickview');
+	ko.components.register('conceptset-quickview', conceptSetPreview);
 	
 });

--- a/js/modules/cohortbuilder/components/CohortExpressionEditor.js
+++ b/js/modules/cohortbuilder/components/CohortExpressionEditor.js
@@ -1,6 +1,6 @@
-define(['knockout', '../options', '../CriteriaGroup', '../CriteriaTypes', '../CohortExpression', '../InclusionRule', 'text!./CohortExpressionEditorTemplate.html', './EndStrategyEditor',
+define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaTypes', '../CohortExpression', '../InclusionRule', 'text!./CohortExpressionEditorTemplate.html', './EndStrategyEditor',
 				'databindings', 'conceptpicker/ConceptPicker', 'css!../css/builder.css', 'css!../css/ddslick.criteria.css', 'ko.sortable'
-			 ], function (ko, options, CriteriaGroup, criteriaTypes, CohortExpression, InclusionRule, template) {
+			 ], function (ko, $, options, CriteriaGroup, criteriaTypes, CohortExpression, InclusionRule, template) {
 	
 	function CohortExpressionEditorViewModel(params) {
 		var self = this;
@@ -276,7 +276,7 @@ define(['knockout', '../options', '../CriteriaGroup', '../CriteriaTypes', '../Co
 			self.selectedInclusionRule(inclusionRule);
 			self.selectedInclusionRuleIndex = params.expression().InclusionRules().indexOf(inclusionRule);
 			console.log("Selected Index: " + self.selectedInclusionRuleIndex);
-		}
+		};
 
 		self.removeAdditionalCriteria = function () {
 			self.expression().AdditionalCriteria(null);
@@ -288,31 +288,29 @@ define(['knockout', '../options', '../CriteriaGroup', '../CriteriaTypes', '../Co
 
 		self.removePrimaryCriteria = function (criteria) {
 			self.expression().PrimaryCriteria().CriteriaList.remove(criteria);
-		}
+		};
 		
 		self.removeCensoringCriteria = function (criteria) {
 			self.expression().CensoringCriteria.remove(criteria);	
-		}
+		};
 
 		self.addInclusionRule = function () {
 			var newInclusionRule = new InclusionRule(null, self.expression().ConceptSets);
 			self.expression().InclusionRules.push(newInclusionRule);
 			self.selectInclusionRule(newInclusionRule);
-		}
+		};
 
 		self.deleteInclusionRule = function (inclusionRule) {
 			self.selectedInclusionRule(null);
 			self.expression().InclusionRules.remove(inclusionRule);
-		}
+		};
 
 		self.copyInclusionRule = function (inclusionRule) {
 			var copiedRule = new InclusionRule(ko.toJS(inclusionRule), self.expression().ConceptSets);
 			copiedRule.name("Copy of: " + copiedRule.name());
 			self.expression().InclusionRules.push(copiedRule);
 			self.selectedInclusionRule(copiedRule);
-		}
-
-		self.addConceptSet = function (item) {}
+		};
 
 		self.addPrimaryCriteriaOptions = {
 			selectText: "Add Initial Event...",
@@ -373,10 +371,10 @@ define(['knockout', '../options', '../CriteriaGroup', '../CriteriaTypes', '../Co
 				if (value === 0 || value) {
 					return value;
 				} else {
-					return
+					return;
 				}
-			}, 2)
-		}
+			}, 2);
+		};
 		
 		// Subscriptions
 		

--- a/js/modules/cohortbuilder/components/CohortExpressionEditorTemplate.html
+++ b/js/modules/cohortbuilder/components/CohortExpressionEditorTemplate.html
@@ -46,7 +46,7 @@
 					<col span="1" class="rule" />
 					<col span="1" class="delete" />
 				</colgroup>
-				<tbody data-bind="sortable: {data: expression().PrimaryCriteria().CriteriaList, connectClass : 'primaryCriteria', options: {cancel: ':input, button, [contenteditable]'}}">
+				<tbody data-bind="sortable: {data: expression().PrimaryCriteria().CriteriaList, connectClass : 'primaryCriteria', options: {cancel: ':input, button, [contenteditable], .undraggable'}}">
 					<tr>
 						<td>
 							<div class="criteria-content">
@@ -99,8 +99,7 @@
 		</div>
 		<div data-bind="eventListener: [
 			 { event: 'click', selector: '.copyInclusionRule', callback: copyInclusionRule},
-			 { event: 'click', selector: '.deleteInclusionRule', callback: deleteInclusionRule},
-			 { event: 'click', selector: '.addConceptSet', callback: addConceptSet}]">
+			 { event: 'click', selector: '.deleteInclusionRule', callback: deleteInclusionRule}]">
 
 			<table style="width: 100%">
 				<colgroup>

--- a/js/modules/cohortbuilder/components/ConceptSetQuickview.js
+++ b/js/modules/cohortbuilder/components/ConceptSetQuickview.js
@@ -1,0 +1,36 @@
+define(['knockout', 'text!./ConceptSetQuickviewTemplate.html'], function (ko, componentTemplate) {
+
+	function ConceptSetQuickviewModel(params) {
+		var self = this;
+		var excludesDefault = true;
+		var descendantsDefault = true;
+		var mappedDefault = true;
+		
+		self.conceptSet = ko.computed(() => ko.utils.unwrapObservable(params.conceptSet));
+		
+		// behaviors
+		
+		self.toggleExcludes = function() {
+			self.conceptSet().expression.items().forEach((item) => item.isExcluded(excludesDefault));
+			excludesDefault = !excludesDefault;
+		};
+
+		self.toggleDescendants = function() {
+			self.conceptSet().expression.items().forEach((item) => item.includeDescendants(descendantsDefault));
+			descendantsDefault = !descendantsDefault;
+		};
+
+		self.toggleMapped = function() {
+			self.conceptSet().expression.items().forEach((item) => item.includeMapped(mappedDefault));
+			mappedDefault = !mappedDefault;
+		};
+		
+	}
+	
+	// return compoonent definition
+	return {
+		viewModel: ConceptSetQuickviewModel,
+		template: componentTemplate
+	};
+
+});

--- a/js/modules/cohortbuilder/components/ConceptSetQuickviewTemplate.html
+++ b/js/modules/cohortbuilder/components/ConceptSetQuickviewTemplate.html
@@ -1,0 +1,17 @@
+
+<table>
+	<thead>
+		<th>Name</th>
+		<th style="width:15px; cursor: pointer; user-select:none" data-bind="click: toggleExcludes">E</th>
+		<th style="width:15px; cursor: pointer; user-select:none" data-bind="click: toggleDescendants">D</th>
+		<th style="width:15px; cursor: pointer; user-select:none" data-bind="click: toggleMapped">M</th>
+	</thead>
+	<tbody data-bind="foreach: conceptSet().expression.items">
+		<tr>
+			<td data-bind="attr:{title: concept.CONCEPT_NAME}"><div style="width:275px; overflow-x: hidden; text-overflow:ellipsis; white-space:nowrap" data-bind="text: concept.CONCEPT_NAME"></div></td>
+			<td><span class="fa fa-check" data-bind="css: {selected: isExcluded}, click: () => isExcluded(!isExcluded())"></span></td>
+			<td><span class="fa fa-check" data-bind="css: {selected: includeDescendants}, click: () => includeDescendants(!includeDescendants())"></span></td>
+			<td><span class="fa fa-check" data-bind="css: {selected: includeMapped}, click: () => includeMapped(!includeMapped())"></span></td>
+		</tr>
+	</tbody>
+</table>

--- a/js/modules/cohortbuilder/components/ConceptSetSelectorTemplate.html
+++ b/js/modules/cohortbuilder/components/ConceptSetSelectorTemplate.html
@@ -1,7 +1,42 @@
-<select data-bind="options: sortedConceptSets, 
-	optionsText: function(item) { return item.name }, 
-	optionsCaption: defaultText, 
-	optionsValue: 'id',
-	value: conceptSetId" class="mediumInputField">
-</select>
-<div class="btn btn-sm btn-success conceptset_selector" aria-expanded="false">Add</div>
+<div class="undraggable" style="position: relative; display: inline">
+	<div style="position:relative" class="btn-group btn-group-sm thumb-dropdown" data-bind="dropup, eventListener: [
+																																	{ event: 'mouseenter', selector: '.conceptset', callback: showConceptSetPreview},	
+																																	{ event: 'hidden.bs.dropdown', callback: hideConceptSetPreview}		
+																																]">
+		<button type="button" class="btn btn-success conceptset_edit" style="max-width:200px; overflow-x: hidden; text-overflow:ellipsis; white-space:nowrap" data-bind="text:conceptSetName, attr:{'title': conceptSetName}"></button>
+		<button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown">
+			<span class="caret"></span>  <!-- caret -->
+			<span class="sr-only" data-bind="text:conceptSetName"></span>
+		</button>
+			
+		<ul class="dropdown-menu dropdown-menu-right" style="height: auto; max-height:200px; width:200px; overflow-x: hidden; padding:4px" role="menu">
+			<li class="dropdown-item" onclick="event.stopPropagation();"><input type="text" style="width:100%; border: solid 1px #9bc1fd; border-radius: 3px" data-bind="textInput: filterText"></li>
+			<!-- ko foreach: filteredConceptSets -->
+			<li class="dropdown-item conceptset" style="cursor:pointer">
+				<a>
+					<div style="max-width:195px; overflow-x: hidden; text-overflow:ellipsis;" data-bind="text: name, attr:{'title': name}, click: $component.itemClicked"></div>
+					<div class="thumbnail" style="position:absolute"><conceptset-quickview params="conceptSet: $data"></conceptset-quickview></div>
+				</a>
+			</li>
+			<!-- ko if: $component.conceptSetId() != null && $index() == 0  -->
+			<li class="divider"></li>			
+			<!-- /ko -->
+			<!-- /ko -->
+			<!-- ko if: filteredConceptSets().length > 1 -->
+			<li class="divider"></li>
+			<!-- /ko -->
+			<li class="conceptset_import" style="cursor:pointer">Import Concept Set</li>
+			<li data-bind="click: clear" style="cursor:pointer">Clear Concept Set</li>
+		</ul>
+		<ul>
+		<!-- ko if: previewVisible -->
+		<div onclick="event.stopPropagation();" class="undraggable" style="border: solid 1px black;padding:5px; z-index: 999; background-color:white; position: absolute; max-height:200px; overflow-y:auto" data-bind="style: { top: `${previewTop()}px`, left: `${previewLeft()}px`}">
+			<div style="background-color:#aaa; font-weight: bold" data-bind="text: previewConceptSet().name"></div>
+			<conceptset-quickview params="conceptSet: previewConceptSet"></conceptset-quickview>
+		</div>
+		<!-- /ko -->
+		</ul>	
+
+	</div>
+
+</div>

--- a/js/modules/cohortbuilder/css/builder.css
+++ b/js/modules/cohortbuilder/css/builder.css
@@ -200,3 +200,19 @@ col.delete {
 	font-family: Verdana, Arial, sans-serif;
 	font-size: .9em;
 }
+
+.thumb-dropdown .dropdown-menu > li {
+    position: relative;
+}
+.thumb-dropdown .dropdown-menu > li > a .thumbnail {
+    position: absolute; 
+    left: 100%;
+    top: -10px;
+    display: none;    
+    width: 350px;
+    height: auto;
+    margin-left: 5px;
+}
+.thumb-dropdown .dropdown-menu > li > a:hover .thumbnail  {
+    display: block;    
+}

--- a/js/modules/databindings/eventListenerBinding.js
+++ b/js/modules/databindings/eventListenerBinding.js
@@ -7,7 +7,7 @@ define(['knockout'], function (ko) {
 			}
 			params.forEach(function (param) {
 				$(element).on(param.event, param.selector, function (event) {
-					param.callback(ko.dataFor(this), event);
+					param.callback(ko.dataFor(this), ko.contextFor(this), event);
 				});
 			});
 		}

--- a/js/styles/atlas.css
+++ b/js/styles/atlas.css
@@ -1759,10 +1759,6 @@ div.demographicCriteria div.criteria-content {
 	margin-top: -5px;
 }
 
-inclusion-rule-editor .btn-group {
-	margin-top: -3px;
-}
-
 inclusion-rule-editor .inclusion-rule-header {
 	margin-bottom: 5px;
 }


### PR DESCRIPTION
This is the implementation of the feature request from @jhardin29 to implement conceptset quickview on the cohort builder.  Changes are as follows:

Cohort Editor now provides the ability to preview a concept set and make minor modifications (exclude, descendants, mapped).
Modified conceptset picker so that dropdowns can be bound to events.
Updated sortable ko binding to version 1.0.1.
Modified event databinding to return binding context with the data item.
Modified concept set browser to only show repository concept sets.

Closes OHDSI/WebAPI#228.