### PR TITLE
Reference external atlascharts libaray.

### DIFF
--- a/js/components/data-sources.js
+++ b/js/components/data-sources.js
@@ -1,4 +1,4 @@
-define(['jquery', 'knockout', 'text!./data-sources.html', 'd3', 'jnj_chart', 'colorbrewer', 'lodash', 'appConfig', 'knockout.dataTables.binding', 'databindings/eventListenerBinding'], function ($, ko, view, d3, jnj_chart, colorbrewer, _, config) {
+define(['jquery', 'knockout', 'text!./data-sources.html', 'd3', 'atlascharts', 'colorbrewer', 'lodash', 'appConfig', 'knockout.dataTables.binding', 'databindings/eventListenerBinding'], function ($, ko, view, d3, jnj_chart, colorbrewer, _, config) {
 	function dataSources(params) {
 		var self = this;
 

--- a/js/components/report-manager.js
+++ b/js/components/report-manager.js
@@ -1,4 +1,4 @@
-define(['knockout', 'text!./report-manager.html', 'd3', 'jnj_chart', 'colorbrewer', 'lodash', 'appConfig', 'knockout.dataTables.binding','faceted-datatable'], function (ko, view, d3, jnj_chart, colorbrewer, _, config) {
+define(['knockout', 'text!./report-manager.html', 'd3', 'atlascharts', 'colorbrewer', 'lodash', 'appConfig', 'knockout.dataTables.binding','faceted-datatable'], function (ko, view, d3, jnj_chart, colorbrewer, _, config) {
 	function reportManager(params) {
 		var self = this;
 		self.model = params.model;

--- a/js/main.js
+++ b/js/main.js
@@ -105,6 +105,7 @@ requirejs.config({
 		"d3": "d3.min",
 		"d3_tip": "d3.tip",
 		"jnj_chart": "jnj.chart",
+		"atlascharts": "https://unpkg.com/@ohdsi/atlascharts@0.0.11/dist/atlascharts.min",
 		"nvd3": "nv.d3",
 		//"lodash": "lodash.min",
 		"lodash": "lodash.4.15.0.full",


### PR DESCRIPTION
Added new moduleID 'atlascharts' to config.
Switched references from jnj_chart to atlascharts where external library could be drop-in replacement.

In contrast to #417, this PR requires minimal changes to the Atlas codebase since the libary follows the same API as the prior jnj_charts library.  The existing jnj_charts library was unchanged, so there is duplication of code between the jnj_charts and the atlascharts library.  This cleanup can be made at a separate time.

D3 version upgrade is not included here.  The hope is that the D3 version update can be made in the atlascharts libary (under a new version) and when we're ready to consume it in Atlas, we just change the atlascharts version reference along with the atlas UI changes needed to interact with the new D3 version.  This effort will can be handled in a separate PR.
