### PR TITLE
allowing for local configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /web.config
+js/config-local.js

--- a/js/config.js
+++ b/js/config.js
@@ -1,17 +1,15 @@
-define([], function () {
+define(['optional!config-local'], function (localConfig) {
 	var config = {};
 
-	config.services = [
-		{
-			name: 'Local',
-			url: 'http://localhost:8080/WebAPI/'
-          }
-		];
-
-	config.webAPIRoot = config.services[0].url;
-	// config.rServicesHost = 'http://localhost:8081/';
+	// default configuration
+	config.services = [{
+		name: 'Local',
+		url: 'http://localhost:8080/WebAPI/'
+	}];
 	config.cohortComparisonResultsEnabled = false;
 	config.userAuthenticationEnabled = false;
 
+	Object.assign(config, localConfig);
+	config.webAPIRoot = config.services[0].url;
 	return config;
 });

--- a/js/config.js
+++ b/js/config.js
@@ -1,5 +1,8 @@
 define(['optional!config-local'], function (localConfig) {
 	var config = {};
+	if (JSON.stringify(localConfig) == JSON.stringify({})) {
+		console.warn(`Local configuration not found.  Using default values. To use a local configuration and suppress 404 errors, create a file called config-local.js under the /js directory`);
+	}
 
 	// default configuration
 	config.services = [{

--- a/js/main.js
+++ b/js/main.js
@@ -63,6 +63,7 @@ requirejs.config({
 		"bootstrap": "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min",
 		"text": "plugins/text",
 		"css": "plugins/css.min",
+		"optional": "plugins/optional",
 		"clipboard": "clipboard.min",
 		"knockout": "knockout.min",
 		"ko.sortable": "https://cdnjs.cloudflare.com/ajax/libs/knockout-sortable/1.1.0/knockout-sortable.min",

--- a/js/plugins/optional.js
+++ b/js/plugins/optional.js
@@ -1,0 +1,27 @@
+define("optional", function factory() {
+	// We have to use a factory function with "return" so that semver-sync
+	// picks up the version number when it checks or bumps.
+	return {
+		version: "0.1.0",
+
+		// The array of failed loads.
+		failed: [],
+
+		load: function load(name, req, onLoad, _config) {
+			if (name.length !== 0) {
+				req([name], onLoad, function failed() {
+					this.failed.push(name);
+					// Undef exists only on the global require, not local ones.
+					requirejs.undef(name);
+
+					// We do not *define* the module but just return a default value for
+					// it. This ensures isolation between calls that require the same
+					// module, sometimes optionally, sometimes not.
+					onLoad({});
+				}.bind(this));
+			} else {
+				onLoad(this);
+			}
+		},
+	};
+});


### PR DESCRIPTION
attempting to provide a way to allow local configuration without editing of config.js, which we would like to remain out of the .gitignore as new features / configurations are introduced.
 
config-local.js would be added to .gitignoreafter initial commit.