### PR TITLE
Handle arrays in faceted data table.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -10,37 +10,37 @@ define(['jquery', 'knockout', 'jnj_chart', 'd3', 'ohdsi.util', 'appConfig', 'web
 		self.pageTitle = ko.pureComputed(function () {
 			var pageTitle = "ATLAS";
 			switch (self.currentView()) {
-			case 'loading':
-				pageTitle = pageTitle + ": Loading";
-				break;
-			case 'home':
-				pageTitle = pageTitle + ": Home";
-				break;
-			case 'search':
-				pageTitle = pageTitle + ": Search";
-				break;
-			case 'conceptsets':
-			case 'conceptset':
-				pageTitle = pageTitle + ": Concept Sets";
-				break;
-			case 'concept':
-				pageTitle = pageTitle + ": Concept";
-				break;
-			case 'cohortdefinitions':
-			case 'cohortdefinition':
-				pageTitle = pageTitle + ": Cohorts";
-				break;
-			case 'irbrowser':
-			case 'iranalysis':
-				pageTitle = pageTitle + ": Incidence Rate";
-				break;
-			case 'estimations':
-			case 'estimation':
-				pageTitle = pageTitle + ": Estimation";
-				break;
-			case 'profiles':
-				pageTitle = pageTitle + ": Profiles";
-				break;
+				case 'loading':
+					pageTitle = pageTitle + ": Loading";
+					break;
+				case 'home':
+					pageTitle = pageTitle + ": Home";
+					break;
+				case 'search':
+					pageTitle = pageTitle + ": Search";
+					break;
+				case 'conceptsets':
+				case 'conceptset':
+					pageTitle = pageTitle + ": Concept Sets";
+					break;
+				case 'concept':
+					pageTitle = pageTitle + ": Concept";
+					break;
+				case 'cohortdefinitions':
+				case 'cohortdefinition':
+					pageTitle = pageTitle + ": Cohorts";
+					break;
+				case 'irbrowser':
+				case 'iranalysis':
+					pageTitle = pageTitle + ": Incidence Rate";
+					break;
+				case 'estimations':
+				case 'estimation':
+					pageTitle = pageTitle + ": Estimation";
+					break;
+				case 'profiles':
+					pageTitle = pageTitle + ": Profiles";
+					break;
 			}
 
 			if (self.hasUnsavedChanges()) {
@@ -50,13 +50,13 @@ define(['jquery', 'knockout', 'jnj_chart', 'd3', 'ohdsi.util', 'appConfig', 'web
 			return pageTitle;
 		});
 		self.sharedState = sharedState;
-		
-		self.initializationComplete = ko.pureComputed(function() {
+
+		self.initializationComplete = ko.pureComputed(function () {
 			return sharedState.appInitializationStatus() != 'initializing';
 		});
-		
+
 		self.initComplete = function () {
-			if (self.sharedState.appInitializationStatus()=='initializing') {
+			if (self.sharedState.appInitializationStatus() == 'initializing') {
 				var routerOptions = {
 					notfound: function () {
 						self.currentView('search');
@@ -188,7 +188,7 @@ define(['jquery', 'knockout', 'jnj_chart', 'd3', 'ohdsi.util', 'appConfig', 'web
 								model: self,
 								sourceKey: (path[0] || null),
 								personId: (path[1] || null),
-								cohortDefinitionId: (path[2] || null) 
+								cohortDefinitionId: (path[2] || null)
 							};
 							self.currentView('profile-manager');
 						});
@@ -341,12 +341,11 @@ define(['jquery', 'knockout', 'jnj_chart', 'd3', 'ohdsi.util', 'appConfig', 'web
             }, {
 				'caption': 'Relationship',
 				'binding': function (o) {
-					values = [];
-					for (var i = 0; i < o.RELATIONSHIPS.length; i++) {
-						values.push(o.RELATIONSHIPS[i].RELATIONSHIP_NAME);
-					}
-					return values;
-				}
+					return $.map(o.RELATIONSHIPS, function (val) {
+						return val.RELATIONSHIP_NAME
+					});
+				},
+				isArray: true,
             }, {
 				'caption': 'Has Records',
 				'binding': function (o) {
@@ -360,15 +359,11 @@ define(['jquery', 'knockout', 'jnj_chart', 'd3', 'ohdsi.util', 'appConfig', 'web
             }, {
 				'caption': 'Distance',
 				'binding': function (o) {
-					values = [];
-					for (var i = 0; i < o.RELATIONSHIPS.length; i++) {
-						if (values.indexOf(o.RELATIONSHIPS[i].RELATIONSHIP_DISTANCE) == -1) {
-							values.push(o.RELATIONSHIPS[i].RELATIONSHIP_DISTANCE);
-						}
-					}
-					return values;
-				}
-            }]
+					return Math.max.apply(Math, o.RELATIONSHIPS.map(function (d) {
+						return d.RELATIONSHIP_DISTANCE;
+					}))
+				},
+			}]
 		};
 
 		self.relatedConceptsColumns = [{
@@ -724,12 +719,12 @@ define(['jquery', 'knockout', 'jnj_chart', 'd3', 'ohdsi.util', 'appConfig', 'web
 				switchContext = data.STANDARD_CONCEPT;
 			}
 			switch (switchContext) {
-			case 'N':
-				$('a', row).css('color', '#a71a19');
-				break;
-			case 'C':
-				$('a', row).css('color', '#a335ee');
-				break;
+				case 'N':
+					$('a', row).css('color', '#a71a19');
+					break;
+				case 'C':
+					$('a', row).css('color', '#a335ee');
+					break;
 			}
 		}
 		self.hasCDM = function (source) {
@@ -765,11 +760,11 @@ define(['jquery', 'knockout', 'jnj_chart', 'd3', 'ohdsi.util', 'appConfig', 'web
 			return '<a class="' + valid + '" href=\"#/concept/' + d.CONCEPT_ID + '\">' + d.CONCEPT_NAME + '</a>';
 		}
 		self.renderBoundLink = function (s, p, d) {
-				return '<a href=\"#/concept/' + d.concept.CONCEPT_ID + '\">' + d.concept.CONCEPT_NAME + '</a>';
-			}
-			// for the current selected concepts:
-			// update the export panel
-			// resolve the included concepts and update the include concept set identifier list
+			return '<a href=\"#/concept/' + d.concept.CONCEPT_ID + '\">' + d.concept.CONCEPT_NAME + '</a>';
+		}
+		// for the current selected concepts:
+		// update the export panel
+		// resolve the included concepts and update the include concept set identifier list
 		self.resolveConceptSetExpression = function () {
 			self.resolvingConceptSetExpression(true);
 			var conceptSetExpression = '{"items" :' + ko.toJSON(sharedState.selectedConcepts()) + '}';
@@ -990,13 +985,13 @@ define(['jquery', 'knockout', 'jnj_chart', 'd3', 'ohdsi.util', 'appConfig', 'web
 						var allAnalysesCompleted = analyses.filter(function (elem) {
 							return self.cohortAnalyses()[i].analyses.indexOf(elem) > -1;
 						}).length == self.cohortAnalyses()[i].analyses.length;
-						if(self.cohortAnalyses()[8].reportKey == 'Heracles Heel'){
-							if(analyses.filter(function (elem) {
-								return self.cohortAnalyses()[i].analyses.indexOf(elem) > -1;
-							}).length > 0){
+						if (self.cohortAnalyses()[8].reportKey == 'Heracles Heel') {
+							if (analyses.filter(function (elem) {
+									return self.cohortAnalyses()[i].analyses.indexOf(elem) > -1;
+								}).length > 0) {
 								sourceAnalysesStatus[self.cohortAnalyses()[i].name] = true;
 							}
-						}else{
+						} else {
 							sourceAnalysesStatus[self.cohortAnalyses()[i].name] = allAnalysesCompleted ? 1 : 0;
 						}
 					}

--- a/js/components/concept-manager.js
+++ b/js/components/concept-manager.js
@@ -3,7 +3,7 @@ define(['knockout', 'text!./concept-manager.html', 'appConfig', 'vocabularyprovi
 		var self = this;
 		self.model = params.model;
 		self.subscriptions = [];
-		
+
 		self.sourceCounts = ko.observableArray();
 		self.loadingSourceCounts = ko.observable(false);
 		self.loadingRelated = ko.observable(false);
@@ -22,9 +22,9 @@ define(['knockout', 'text!./concept-manager.html', 'appConfig', 'vocabularyprovi
 		self.subscriptions.push(
 			self.model.currentConceptMode.subscribe(function (mode) {
 				switch (mode) {
-				case 'recordcounts':
-					self.loadRecordCounts();
-					break;
+					case 'recordcounts':
+						self.loadRecordCounts();
+						break;
 				}
 			})
 		);
@@ -58,12 +58,11 @@ define(['knockout', 'text!./concept-manager.html', 'appConfig', 'vocabularyprovi
             }, {
 				'caption': 'Relationship',
 				'binding': function (o) {
-					values = [];
-					for (var i = 0; i < o.RELATIONSHIPS.length; i++) {
-						values.push(o.RELATIONSHIPS[i].RELATIONSHIP_NAME);
-					}
-					return values;
-				}
+					return $.map(o.RELATIONSHIPS, function (val) {
+						return val.RELATIONSHIP_NAME
+					});
+				},
+				isArray: true,
             }, {
 				'caption': 'Has Records',
 				'binding': function (o) {
@@ -77,15 +76,11 @@ define(['knockout', 'text!./concept-manager.html', 'appConfig', 'vocabularyprovi
             }, {
 				'caption': 'Distance',
 				'binding': function (o) {
-					values = [];
-					for (var i = 0; i < o.RELATIONSHIPS.length; i++) {
-						if (values.indexOf(o.RELATIONSHIPS[i].RELATIONSHIP_DISTANCE) == -1) {
-							values.push(o.RELATIONSHIPS[i].RELATIONSHIP_DISTANCE);
-						}
-					}
-					return values;
-				}
-            }]
+					return Math.max.apply(Math, o.RELATIONSHIPS.map(function (d) {
+						return d.RELATIONSHIP_DISTANCE;
+					}))
+				},
+			}]
 		};
 
 		self.relatedConceptsColumns = [{
@@ -477,9 +472,9 @@ define(['knockout', 'text!./concept-manager.html', 'appConfig', 'vocabularyprovi
 		};
 
 		self.loadConcept(self.model.currentConceptId());
-		
+
 		self.dispose = function () {
-			self.subscriptions.forEach(function(subscription) {
+			self.subscriptions.forEach(function (subscription) {
 				subscription.dispose();
 			});
 		};

--- a/js/components/faceted-datatable.js
+++ b/js/components/faceted-datatable.js
@@ -86,9 +86,10 @@ define(['knockout', 'text!./faceted-datatable.html', 'crossfilter', 'colvis', ],
 				if (self.options && self.options.Facets) {
 					// Iterate over the facets and set the dimensions
 					$.each(self.options.Facets, function (i, facetConfig) {
+						var isArray = facetConfig.isArray || false;
 						var dimension = self.data().dimension(function (d) {
 							return self.facetDimensionHelper(facetConfig.binding(d));
-						});
+						}, isArray);
 						var facet = {
 							'caption': facetConfig.caption,
 							'binding': facetConfig.binding,

--- a/js/config.js
+++ b/js/config.js
@@ -2,12 +2,12 @@ define([], function () {
 	var config = {};
 
 	config.services = [
-        {
+		{
 			name: 'Local',
 			url: 'http://localhost:8080/WebAPI/'
           }
 		];
-	
+
 	config.webAPIRoot = config.services[0].url;
 	// config.rServicesHost = 'http://localhost:8081/';
 	config.cohortComparisonResultsEnabled = false;

--- a/js/main.js
+++ b/js/main.js
@@ -71,7 +71,7 @@ requirejs.config({
 		"datatables.net-buttons": "jquery.dataTables.buttons.min",
 		"datatables.net-buttons-html5": "jquery.dataTables.buttons.html5.min",
 		"colvis": "jquery.dataTables.colVis.min",
-		"crossfilter": "https://cdnjs.cloudflare.com/ajax/libs/crossfilter2/1.4.0/crossfilter.min",
+		"crossfilter": "https://cdnjs.cloudflare.com/ajax/libs/crossfilter2/1.4.1/crossfilter.min",
 		"director": "director.min",
 		"search": "components/search",
 		"configuration": "components/configuration",


### PR DESCRIPTION
Provides support for passing in arrays as a facet filter. This was necessary for a bug found by @ericaVoss for the 'Related Concept' tab for a concept. The root cause is that the facets for 'Relationship' and 'Distance' were based on an array of nested values returned from the REST endpoint. This change provide a mechanism to specify if a given facet dimension is an array per https://github.com/crossfilter/crossfilter/wiki/API-Reference#dimension_with_arrays. Furthermore, it changes the specification for the facet so that each dimension can be interrogated for the proper value.

Also bumps the crossfilter reference from 1.4.0 to 1.4.1 since it contained a fix related to array dimensions utilized here.