### PR TITLE
New front end functionality to restrict to records with the same visit_occurrence_id

### DIFF
--- a/js/modules/cohortbuilder/AdditionalCriteria.js
+++ b/js/modules/cohortbuilder/AdditionalCriteria.js
@@ -4,6 +4,7 @@ define(function (require, exports, module) {
 	var CriteriaTypes = require('./CriteriaTypes');		
 	var Occurrence = require('./InputTypes/Occurrence');
 	var Window = require('./InputTypes/Window');
+	var RestrictVisit = require('./InputTypes/RestrictVisit');
 	
 	var debug = false;
 
@@ -15,6 +16,7 @@ define(function (require, exports, module) {
 		self.StartWindow = new Window(data.StartWindow);
 		self.EndWindow = ko.observable(data.EndWindow && new Window(data.EndWindow));
 		self.Occurrence = new Occurrence(data.Occurrence);
+		self.RestrictVisit = new RestrictVisit(data.RestrictVisit);
 	}
 	
 	module.exports = AdditionalCriteria;

--- a/js/modules/cohortbuilder/InputTypes/RestrictVisit.js
+++ b/js/modules/cohortbuilder/InputTypes/RestrictVisit.js
@@ -1,0 +1,11 @@
+define(['knockout'], function (ko) {
+	
+		function RestrictVisit(data) {
+				var self = this;
+				data = data || {};
+				
+				self.RestrictVisit = ko.observable(data.RestrictVisit || false);
+		}
+		
+		return RestrictVisit;
+});

--- a/js/modules/cohortbuilder/components/CriteriaGroup.js
+++ b/js/modules/cohortbuilder/components/CriteriaGroup.js
@@ -292,6 +292,22 @@ define(['knockout', '../CriteriaTypes','../CriteriaGroup', '../InputTypes/Window
 				data.selectedData.action();
 			}
 		}
+		
+		// do not show restrict visit option for criteria where visit occurrence id is set to null
+		self.hasVO = function (data) {
+			switch ( self.getCriteriaComponent(data) ) {
+				case "condition-era-criteria":
+				case "death-criteria":
+				case "drug-era-criteria":
+				case "dose-era-criteria":
+				case "observation-period-criteria":
+				case "specimen-criteria":
+					return false;
+					break;
+				default:
+					return true;
+			}
+		}
 	}
 
 	// return compoonent definition

--- a/js/modules/cohortbuilder/components/CriteriaGroupTemplate.html
+++ b/js/modules/cohortbuilder/components/CriteriaGroupTemplate.html
@@ -91,6 +91,12 @@
 									 <span class="linkish" data-bind="click: $component.addEndWindow">and ending any time.</span>
 									<!-- /ko -->
 								</div>
+	
+								<div class="restrictVisitSection" data-bind="if: $component.hasVO($data.Criteria)">
+									<input type="checkbox" data-bind="checked: RestrictVisit.RestrictVisit">
+									<label>Restrict to the Same Visit Occurrence</label>
+								</div>
+								
 							</div>
 						</td>
 						<td>

--- a/js/modules/cohortdefinitionviewer/components/CriteriaGroupTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/CriteriaGroupTemplate.html
@@ -24,6 +24,9 @@
 			<!-- ko if: EndWindow -->
 			and ending between <window-input-viewer params="Window: EndWindow"></window-input-viewer> event index date
 			<!-- /ko -->
+			<br><span data-bind="text: RestrictVisit.RestrictVisit() ? 'occurring within the same visit' : ''"></span>
+			
+			
 		</div>	
 	</li>
 <!-- /ko -->


### PR DESCRIPTION
This PR adds new functionality in Atlas. 

UX to circe-be functionality to restrict qualified-events to the same visit_occurrence_id. _era tables, death, observation period, specimen are excluded from this functionality.

https://github.com/OHDSI/Atlas/issues/454
https://github.com/OHDSI/WebAPI/issues/217
https://github.com/OHDSI/circe-be/pull/7
https://github.com/OHDSI/circe-be/pull/8

@chrisknoll 
