### PR TITLE
UI functionality to choose collapse strategy exit criteria

### DIFF
--- a/js/modules/cohortbuilder/CohortExpression.js
+++ b/js/modules/cohortbuilder/CohortExpression.js
@@ -26,7 +26,7 @@ define(function (require, exports) {
 		self.CensoringCriteria = ko.observableArray(data.CensoringCriteria && data.CensoringCriteria.map(function (criteria) {
 			return CriteriaTypes.GetCriteriaFromObject(criteria, self.ConceptSets);
 		}));
-		self.CollapseSettings = {CollapseType: ko.observable(data.CollapseSettings && data.CollapseSettings.CollapseType || "Era"), EraPad: ko.observable(data.CollapseSettings && data.CollapseSettings.EraPad || 0 ) }
+		self.CollapseSettings = {CollapseType: ko.observable(data.CollapseSettings && data.CollapseSettings.CollapseType || "ERA"), EraPad: ko.observable(data.CollapseSettings && data.CollapseSettings.EraPad || 0 ) }
 		
 	}
 	return CohortExpression;

--- a/js/modules/cohortbuilder/CohortExpression.js
+++ b/js/modules/cohortbuilder/CohortExpression.js
@@ -7,6 +7,7 @@ define(function (require, exports) {
 	var InclusionRule = require('./InclusionRule');
 	var EndStrategies = require('./EndStrategies');
 	var CriteriaTypes = require('./CriteriaTypes');
+
 	
 	function CohortExpression(data) {
 		var self = this;
@@ -26,6 +27,7 @@ define(function (require, exports) {
 		self.CensoringCriteria = ko.observableArray(data.CensoringCriteria && data.CensoringCriteria.map(function (criteria) {
 			return CriteriaTypes.GetCriteriaFromObject(criteria, self.ConceptSets);
 		}));
+		self.CollapseSettings = {CollapseType: ko.observable(data.CollapseSettings && data.CollapseSettings.CollapseType || "Era"), EraPad: ko.observable(data.CollapseSettings && data.CollapseSettings.EraPad || "0") }
 		
 	}
 	return CohortExpression;

--- a/js/modules/cohortbuilder/CohortExpression.js
+++ b/js/modules/cohortbuilder/CohortExpression.js
@@ -7,7 +7,6 @@ define(function (require, exports) {
 	var InclusionRule = require('./InclusionRule');
 	var EndStrategies = require('./EndStrategies');
 	var CriteriaTypes = require('./CriteriaTypes');
-
 	
 	function CohortExpression(data) {
 		var self = this;
@@ -27,7 +26,7 @@ define(function (require, exports) {
 		self.CensoringCriteria = ko.observableArray(data.CensoringCriteria && data.CensoringCriteria.map(function (criteria) {
 			return CriteriaTypes.GetCriteriaFromObject(criteria, self.ConceptSets);
 		}));
-		self.CollapseSettings = {CollapseType: ko.observable(data.CollapseSettings && data.CollapseSettings.CollapseType || "Era"), EraPad: ko.observable(data.CollapseSettings && data.CollapseSettings.EraPad || "0") }
+		self.CollapseSettings = {CollapseType: ko.observable(data.CollapseSettings && data.CollapseSettings.CollapseType || "Era"), EraPad: ko.observable(data.CollapseSettings && data.CollapseSettings.EraPad || 0 ) }
 		
 	}
 	return CohortExpression;

--- a/js/modules/cohortbuilder/components/CohortExpressionEditor.js
+++ b/js/modules/cohortbuilder/components/CohortExpressionEditor.js
@@ -1,6 +1,6 @@
-define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaTypes', '../CohortExpression', '../InclusionRule', 'text!./CohortExpressionEditorTemplate.html', './EndStrategyEditor',
+define(['knockout', '../options', '../CriteriaGroup', '../CriteriaTypes', '../CohortExpression', '../InclusionRule', 'text!./CohortExpressionEditorTemplate.html', './EndStrategyEditor',
 				'databindings', 'conceptpicker/ConceptPicker', 'css!../css/builder.css', 'css!../css/ddslick.criteria.css', 'ko.sortable'
-			 ], function (ko, $, options, CriteriaGroup, criteriaTypes, CohortExpression, InclusionRule, template) {
+			 ], function (ko, options, CriteriaGroup, criteriaTypes, CohortExpression, InclusionRule, template) {
 	
 	function CohortExpressionEditorViewModel(params) {
 		var self = this;
@@ -276,7 +276,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 			self.selectedInclusionRule(inclusionRule);
 			self.selectedInclusionRuleIndex = params.expression().InclusionRules().indexOf(inclusionRule);
 			console.log("Selected Index: " + self.selectedInclusionRuleIndex);
-		};
+		}
 
 		self.removeAdditionalCriteria = function () {
 			self.expression().AdditionalCriteria(null);
@@ -288,29 +288,31 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 
 		self.removePrimaryCriteria = function (criteria) {
 			self.expression().PrimaryCriteria().CriteriaList.remove(criteria);
-		};
+		}
 		
 		self.removeCensoringCriteria = function (criteria) {
 			self.expression().CensoringCriteria.remove(criteria);	
-		};
+		}
 
 		self.addInclusionRule = function () {
 			var newInclusionRule = new InclusionRule(null, self.expression().ConceptSets);
 			self.expression().InclusionRules.push(newInclusionRule);
 			self.selectInclusionRule(newInclusionRule);
-		};
+		}
 
 		self.deleteInclusionRule = function (inclusionRule) {
 			self.selectedInclusionRule(null);
 			self.expression().InclusionRules.remove(inclusionRule);
-		};
+		}
 
 		self.copyInclusionRule = function (inclusionRule) {
 			var copiedRule = new InclusionRule(ko.toJS(inclusionRule), self.expression().ConceptSets);
 			copiedRule.name("Copy of: " + copiedRule.name());
 			self.expression().InclusionRules.push(copiedRule);
 			self.selectedInclusionRule(copiedRule);
-		};
+		}
+
+		self.addConceptSet = function (item) {}
 
 		self.addPrimaryCriteriaOptions = {
 			selectText: "Add Initial Event...",
@@ -371,10 +373,10 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				if (value === 0 || value) {
 					return value;
 				} else {
-					return;
+					return
 				}
-			}, 2);
-		};
+			}, 2)
+		}
 		
 		// Subscriptions
 		

--- a/js/modules/cohortbuilder/components/CohortExpressionEditor.js
+++ b/js/modules/cohortbuilder/components/CohortExpressionEditor.js
@@ -1,6 +1,6 @@
-define(['knockout', '../options', '../CriteriaGroup', '../CriteriaTypes', '../CohortExpression', '../InclusionRule', 'text!./CohortExpressionEditorTemplate.html', './EndStrategyEditor',
+define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaTypes', '../CohortExpression', '../InclusionRule', 'text!./CohortExpressionEditorTemplate.html', './EndStrategyEditor',
 				'databindings', 'conceptpicker/ConceptPicker', 'css!../css/builder.css', 'css!../css/ddslick.criteria.css', 'ko.sortable'
-			 ], function (ko, options, CriteriaGroup, criteriaTypes, CohortExpression, InclusionRule, template) {
+			 ], function (ko, $, options, CriteriaGroup, criteriaTypes, CohortExpression, InclusionRule, template) {
 	
 	function CohortExpressionEditorViewModel(params) {
 		var self = this;
@@ -276,7 +276,7 @@ define(['knockout', '../options', '../CriteriaGroup', '../CriteriaTypes', '../Co
 			self.selectedInclusionRule(inclusionRule);
 			self.selectedInclusionRuleIndex = params.expression().InclusionRules().indexOf(inclusionRule);
 			console.log("Selected Index: " + self.selectedInclusionRuleIndex);
-		}
+		};
 
 		self.removeAdditionalCriteria = function () {
 			self.expression().AdditionalCriteria(null);
@@ -288,31 +288,29 @@ define(['knockout', '../options', '../CriteriaGroup', '../CriteriaTypes', '../Co
 
 		self.removePrimaryCriteria = function (criteria) {
 			self.expression().PrimaryCriteria().CriteriaList.remove(criteria);
-		}
+		};
 		
 		self.removeCensoringCriteria = function (criteria) {
 			self.expression().CensoringCriteria.remove(criteria);	
-		}
+		};
 
 		self.addInclusionRule = function () {
 			var newInclusionRule = new InclusionRule(null, self.expression().ConceptSets);
 			self.expression().InclusionRules.push(newInclusionRule);
 			self.selectInclusionRule(newInclusionRule);
-		}
+		};
 
 		self.deleteInclusionRule = function (inclusionRule) {
 			self.selectedInclusionRule(null);
 			self.expression().InclusionRules.remove(inclusionRule);
-		}
+		};
 
 		self.copyInclusionRule = function (inclusionRule) {
 			var copiedRule = new InclusionRule(ko.toJS(inclusionRule), self.expression().ConceptSets);
 			copiedRule.name("Copy of: " + copiedRule.name());
 			self.expression().InclusionRules.push(copiedRule);
 			self.selectedInclusionRule(copiedRule);
-		}
-
-		self.addConceptSet = function (item) {}
+		};
 
 		self.addPrimaryCriteriaOptions = {
 			selectText: "Add Initial Event...",
@@ -373,10 +371,10 @@ define(['knockout', '../options', '../CriteriaGroup', '../CriteriaTypes', '../Co
 				if (value === 0 || value) {
 					return value;
 				} else {
-					return
+					return;
 				}
-			}, 2)
-		}
+			}, 2);
+		};
 		
 		// Subscriptions
 		

--- a/js/modules/cohortbuilder/components/CohortExpressionEditorTemplate.html
+++ b/js/modules/cohortbuilder/components/CohortExpressionEditorTemplate.html
@@ -215,7 +215,7 @@
 			<ul>
 				<li>
 					Specify era collapse gap size: 
-					<select data-bind="options: $component.options.dayOptions, value: EraPad"></select> days
+					<span contenteditable="true" class="numericInputField dropdown" data-bind="htmlValue: EraPad.numeric(), eventType: 'blur', ko_autocomplete: { value: EraPad, source: $component.options.dayOptions, minLength: 0, maxShowItems: 10, scroll: true }" /> days
 				</li>
 			</ul>
 		</div>

--- a/js/modules/cohortbuilder/components/CohortExpressionEditorTemplate.html
+++ b/js/modules/cohortbuilder/components/CohortExpressionEditorTemplate.html
@@ -46,7 +46,7 @@
 					<col span="1" class="rule" />
 					<col span="1" class="delete" />
 				</colgroup>
-				<tbody data-bind="sortable: {data: expression().PrimaryCriteria().CriteriaList, connectClass : 'primaryCriteria', options: {cancel: ':input, button, [contenteditable]'}}">
+				<tbody data-bind="sortable: {data: expression().PrimaryCriteria().CriteriaList, connectClass : 'primaryCriteria', options: {cancel: ':input, button, [contenteditable], .undraggable'}}">
 					<tr>
 						<td>
 							<div class="criteria-content">
@@ -99,8 +99,7 @@
 		</div>
 		<div data-bind="eventListener: [
 			 { event: 'click', selector: '.copyInclusionRule', callback: copyInclusionRule},
-			 { event: 'click', selector: '.deleteInclusionRule', callback: deleteInclusionRule},
-			 { event: 'click', selector: '.addConceptSet', callback: addConceptSet}]">
+			 { event: 'click', selector: '.deleteInclusionRule', callback: deleteInclusionRule}]">
 
 			<table style="width: 100%">
 				<colgroup>
@@ -205,8 +204,8 @@
 				No censoring events selected.
 			</div>
 		</div>	
-	</div>	
-	
+	</div>
+
 	<div role="tabpanel" data-bind="css: { active: $component.expressionMode() == 'entry' || $component.expressionMode() == 'exit' || $component.expressionMode() == 'all'}" class="tab-pane">
 		<div class="heading"><b>Cohort Collapse Strategy</b></div>
 		<br>The default selection, Era, will collapse overlapping date ranges for the same subject into a continuous period.
@@ -223,4 +222,5 @@
 			</ul>
 		</div>
 	</div>
+
 </div>

--- a/js/modules/cohortbuilder/components/CohortExpressionEditorTemplate.html
+++ b/js/modules/cohortbuilder/components/CohortExpressionEditorTemplate.html
@@ -206,21 +206,18 @@
 		</div>	
 	</div>
 
-	<div role="tabpanel" data-bind="css: { active: $component.expressionMode() == 'entry' || $component.expressionMode() == 'exit' || $component.expressionMode() == 'all'}" class="tab-pane">
-		<div class="heading"><b>Cohort Collapse Strategy</b></div>
-		<br>The default selection, Era, will collapse overlapping date ranges for the same subject into a continuous period.
-			<br>
+	<div role="tabpanel" data-bind="css: { active: $component.expressionMode() == 'exit' || $component.expressionMode() == 'all'}" class="tab-pane">
+		<div class="heading">
+			<b>Cohort Collapse Strategy</b>
+			This strategy collapses events into eras of a continous period and eliminates the duplicate rows for the same subjects.  
+		</div>
 		<div style="padding: 5px 0px" data-bind="with: expression().CollapseSettings">
 			<ul>
-				<li>Collapse Strategy Type:
-					<select data-bind="options: $component.options.collapseStrategyOptions, value: CollapseType"></select>
-				</li>
 				<li>
-					Pad by: 
+					Specify era collapse gap size: 
 					<select data-bind="options: $component.options.dayOptions, value: EraPad"></select> days
 				</li>
 			</ul>
 		</div>
 	</div>
-
 </div>

--- a/js/modules/cohortbuilder/components/CohortExpressionEditorTemplate.html
+++ b/js/modules/cohortbuilder/components/CohortExpressionEditorTemplate.html
@@ -46,7 +46,7 @@
 					<col span="1" class="rule" />
 					<col span="1" class="delete" />
 				</colgroup>
-				<tbody data-bind="sortable: {data: expression().PrimaryCriteria().CriteriaList, connectClass : 'primaryCriteria', options: {cancel: ':input, button, [contenteditable], .undraggable'}}">
+				<tbody data-bind="sortable: {data: expression().PrimaryCriteria().CriteriaList, connectClass : 'primaryCriteria', options: {cancel: ':input, button, [contenteditable]'}}">
 					<tr>
 						<td>
 							<div class="criteria-content">
@@ -99,7 +99,8 @@
 		</div>
 		<div data-bind="eventListener: [
 			 { event: 'click', selector: '.copyInclusionRule', callback: copyInclusionRule},
-			 { event: 'click', selector: '.deleteInclusionRule', callback: deleteInclusionRule}]">
+			 { event: 'click', selector: '.deleteInclusionRule', callback: deleteInclusionRule},
+			 { event: 'click', selector: '.addConceptSet', callback: addConceptSet}]">
 
 			<table style="width: 100%">
 				<colgroup>
@@ -205,4 +206,21 @@
 			</div>
 		</div>	
 	</div>	
+	
+	<div role="tabpanel" data-bind="css: { active: $component.expressionMode() == 'entry' || $component.expressionMode() == 'exit' || $component.expressionMode() == 'all'}" class="tab-pane">
+		<div class="heading"><b>Cohort Collapse Strategy</b></div>
+		<br>The default selection, Era, will collapse overlapping date ranges for the same subject into a continuous period.
+			<br>
+		<div style="padding: 5px 0px" data-bind="with: expression().CollapseSettings">
+			<ul>
+				<li>Collapse Strategy Type:
+					<select data-bind="options: $component.options.collapseStrategyOptions, value: CollapseType"></select>
+				</li>
+				<li>
+					Pad by: 
+					<select data-bind="options: $component.options.dayOptions, value: EraPad"></select> days
+				</li>
+			</ul>
+		</div>
+	</div>
 </div>

--- a/js/modules/cohortbuilder/options.js
+++ b/js/modules/cohortbuilder/options.js
@@ -79,7 +79,6 @@ define([], function () {
         id: "0"
 		}];
 		
-	options.collapseStrategyOptions = ['Era', 'None'];
 
     return options;
 });

--- a/js/modules/cohortbuilder/options.js
+++ b/js/modules/cohortbuilder/options.js
@@ -78,6 +78,9 @@ define([], function () {
         name: "No",
         id: "0"
 		}];
-
+	
+	options.collapseStrategyOptions = ['Era', 'None'];
+	
+	
     return options;
 });

--- a/js/modules/cohortbuilder/options.js
+++ b/js/modules/cohortbuilder/options.js
@@ -78,9 +78,8 @@ define([], function () {
         name: "No",
         id: "0"
 		}];
-	
+		
 	options.collapseStrategyOptions = ['Era', 'None'];
-	
-	
+
     return options;
 });

--- a/js/modules/cohortdefinitionviewer/components/CohortExpressionViewerTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/CohortExpressionViewerTemplate.html
@@ -58,3 +58,7 @@ Exit Cohort based on the following:
 </ul>
 <!-- /ko -->
 
+<div class="heading">Cohort Collapse Strategy:</div>
+<span data-bind="with: expression().CollapseSettings">
+	Collapse cohort by era with a gap size of <span class="numericField" data-bind="text: EraPad" /> days.
+</span>


### PR DESCRIPTION

UI functionality only. Additional work is needed to make changes to cohort-constructor logic based on user input.

UI for era-fy 

https://github.com/OHDSI/WebAPI/pull/234
https://github.com/OHDSI/WebAPI/issues/217
https://github.com/OHDSI/Atlas/issues/414
https://github.com/OHDSI/Atlas/issues/375
https://github.com/OHDSI/Atlas/issues/407

@chrisknoll 