### PR TITLE
add horizontal bar for data completeness

### DIFF
--- a/js/components/report-manager.html
+++ b/js/components/report-manager.html
@@ -53,7 +53,13 @@
 <div id="reportDataCompleteness" data-bind="if: model.currentReport() == 'Data Completeness' && !model.loadingReport()">
 	<div class="pad-10 report">
 		<div class="reportHeading"><i class="fa fa-area-chart"></i> Data Completeness (<span data-bind="text:$component.model.reportSourceKey()"></span>)</div>
-		<faceted-datatable params="{columns: $component.dataCompletColumns, reference:$component.dataCompleteReference, options:$component.dataCompleteOptions }"></faceted-datatable>
+		<faceted-datatable params="{columns: $component.dataCompletColumns, reference:$component.dataCompleteReference, options:$component.dataCompleteOptions, rowClick:$component.dataCompleteRowClick }"></faceted-datatable>
+	</div>
+	<div class="pad-10 report">
+		<span data-bind="text:$component.currentAgeGroup()"></span>
+	</div>
+	<div class="pad-10 report">
+		<svg width="960" height="500"></svg>
 	</div>
 </div>
 

--- a/js/components/report-manager.js
+++ b/js/components/report-manager.js
@@ -60,7 +60,7 @@ define(['knockout', 'text!./report-manager.html', 'd3', 'atlascharts', 'colorbre
 				'binding': d => {
 					return ''
 				}
-					}]
+			}]
 		};
 
 		self.dataCompletColumns = [{
@@ -78,6 +78,8 @@ define(['knockout', 'text!./report-manager.html', 'd3', 'atlascharts', 'colorbre
 				}];
 
 		self.careSiteDatatable;
+		
+		self.currentAgeGroup = ko.observable();
 
 		self.reportTriggerRunSuscription = self.model.reportTriggerRun.subscribe(function (newValue) {
 			if (newValue) {
@@ -1909,8 +1911,15 @@ define(['knockout', 'text!./report-manager.html', 'd3', 'atlascharts', 'colorbre
 							self.model.loadingReport(false);
 
 							self.dataCompleteReference(data);
+
+							var initOneBarData = self.normalizeArray(data.filter(function (d) {
+								return d.covariance == "0~10";
+							}), true);
+
+							self.showHorizontalBar(initOneBarData);
 						}
 					});
+					
 					break; // Data Completeness report
 				case 'Entropy':
 					$.ajax({
@@ -1983,6 +1992,80 @@ define(['knockout', 'text!./report-manager.html', 'd3', 'atlascharts', 'colorbre
 					});
 					break; // Entropy report
 			}
+		}
+		
+		self.showHorizontalBar = function(oneBarData){
+			if(svg){
+				svg.remove();
+			}
+			
+			self.currentAgeGroup('Age group of: ' + oneBarData.covariance);
+			
+			var svg = d3.select("svg");
+		    margin = {top: 20, right: 20, bottom: 30, left: 80},
+		    width = +svg.attr("width") - margin.left - margin.right,
+		    height = +svg.attr("height") - margin.top - margin.bottom;
+		  
+			var tooltip = d3.select("body").append("div").style('position', 'absolute')
+				.style('display', 'none')
+				.style('min-width', '80px')
+				.style('height', 'auto')
+				.style('background', 'none repeat scroll 0 0 #ffffff')
+				.style('border', '1px solid #6F257F')
+				.style('padding', '14px')
+				.style('text-align', 'center');
+		  
+			var x = d3.scaleLinear().range([0, width]);
+			var y = d3.scaleBand().range([height, 0]);
+
+			var g = svg.append("g")
+				.attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+		  
+			var barDataTxt = "[{\"attr\":\"Gender\", \"value\":" + oneBarData.genderP 
+				+ "}, {\"attr\":\"Race\", \"value\":" + oneBarData.raceP 
+				+ "}, {\"attr\":\"Ethnicity\", \"value\":" + oneBarData.ethP + "}]";
+
+
+			var barData = JSON.parse(barDataTxt);
+		  	x.domain([0, d3.max(barData, function(d) { return 100; })]);
+		  	y.domain(barData.map(function(d) { return d.attr; })).padding(0.1);
+
+		    g.append("g")
+		        .attr("class", "x axis")
+		       	.attr("transform", "translate(0," + height + ")")
+		      	.call(d3.axisBottom(x).ticks(5).tickFormat(function(d) { return parseInt(d); }).tickSizeInner([-height]));
+		    
+		    //label for the x axis
+		    svg.append("text")             
+		        .attr("transform",
+		              "translate(" + (width/2) + " ," + (height + margin.top + 20) + ")")
+		        .style("text-anchor", "middle")
+		        .text("Percentage");
+		    
+		    g.append("g")
+		        .attr("class", "y axis")
+		        .call(d3.axisLeft(y));
+
+		    g.selectAll(".bar")
+		        .data(barData)
+		        .enter().append("rect")
+		        .attr("class", "bar")
+		        .attr("x", 0)
+		        .attr("height", y.bandwidth())
+		        .attr("y", function(d) { return y(d.attr); })
+		        .attr("width", function(d) { return x(d.value); })
+		        .on("mousemove", function(d){
+		            tooltip
+		              .style("left", d3.event.pageX - 50 + "px")
+		              .style("top", d3.event.pageY - 70 + "px")
+		              .style("display", "inline-block")
+		              .html((d.attr) + "<br>" + (d.value) + "%");
+		        })
+		    	.on("mouseout", function(d){ tooltip.style("display", "none");});
+		}
+		
+		self.dataCompleteRowClick = function (d){
+			self.showHorizontalBar(d);
 		}
 
 		// drilldown functions


### PR DESCRIPTION
@anthonysena Hi Anthony, this is a feature improvement for data completeness report under cohort analysis for [issue 223](https://github.com/OHDSI/WebAPI/issues/223) and [issue 217](https://github.com/OHDSI/WebAPI/issues/217).

- report-manager.html: add svg div
- report-manager.js: showHorizontalBar() function for drawing bars,
dataCompleteRowClick for making facet-datatable clickable for changing
bars.

Here's a screenshot about the component:
<img width="1203" alt="screen shot 2017-11-13 at 7 06 28 pm" src="https://user-images.githubusercontent.com/10854641/33732848-c0152c16-db55-11e7-8990-5e7f82dee777.png">
