### PR TITLE
Fixed redundant quickview component causing a slowdown in page.

### DIFF
--- a/js/modules/cohortbuilder/components/ConceptSetSelectorTemplate.html
+++ b/js/modules/cohortbuilder/components/ConceptSetSelectorTemplate.html
@@ -15,7 +15,6 @@
 			<li class="dropdown-item conceptset" style="cursor:pointer">
 				<a>
 					<div style="max-width:195px; overflow-x: hidden; text-overflow:ellipsis;" data-bind="text: name, attr:{'title': name}, click: $component.itemClicked"></div>
-					<div class="thumbnail" style="position:absolute"><conceptset-quickview params="conceptSet: $data"></conceptset-quickview></div>
 				</a>
 			</li>
 			<!-- ko if: $component.conceptSetId() != null && $index() == 0  -->


### PR DESCRIPTION
This PR addresses an issue that was identified when looking at cohort definitions with large numbers of concept sets.  A UI component was being rendered needlessly which was causing the UI to hang.
