### PR TITLE
Centralized token refresh

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -67,20 +67,11 @@ define(['jquery', 'knockout', 'ohdsi.util', 'appConfig', 'webapi/AuthAPI', 'weba
 			});
 
 			self.initComplete = function () {
-					var prevToken = authApi.token();
-					var routerOptions = {
-						notfound: function () {
-							self.currentView('search');
-						},
-						on: function () {
-							self.currentView('loading');
-							var promise = (self.config.userAuthenticationEnabled && (authApi.token() != null || (prevToken != null && authApi.token() === null))) ? authApi.refreshToken : null;
-							$.when(promise).done(function(){
-								prevToken = authApi.token();
-								self.currentView('loading');
-							});
-						}
-					};
+				var routerOptions = {
+					notfound: function () {
+						self.currentView('search');
+					},
+				};
 				var routes = {
 					'/': function () {
 						document.location = "#/home";
@@ -348,7 +339,22 @@ define(['jquery', 'knockout', 'ohdsi.util', 'appConfig', 'webapi/AuthAPI', 'weba
 					},
 				};
 
-				self.router = new Router(routes)
+                const asyncBefore = function() {
+                	// Refresh auth token
+                	return (self.config.userAuthenticationEnabled && authApi.token() != null && authApi.tokenExpirationDate() > new Date()) ? authApi.refreshToken() : new Promise(resolve => resolve());
+                };
+
+                // Since the router's "before" hook doesn't work with promises,
+				// there is a need to wrap the routes manually
+                const routesWithRefreshedToken = Object.keys(routes).reduce((accumulator, key) => {
+                	accumulator[key] = function() {
+                        self.currentView('loading');
+                		asyncBefore().then(() => routes[key].apply(null, arguments));
+                    };
+                	return accumulator;
+				}, {});
+
+				self.router = new Router(routesWithRefreshedToken)
 					.configure(routerOptions);
 				self.router.qs = function () {
 					return querystring.parse(window.location.href.split('?')[1]);

--- a/js/components/cohort-definitions/cohort-definition-manager.js
+++ b/js/components/cohort-definitions/cohort-definition-manager.js
@@ -373,9 +373,6 @@ define(['knockout', 'text!./cohort-definition-manager.html',
 			// reset view after save
 			cohortDefinitionAPI.deleteCohortDefinition(self.model.currentCohortDefinition().id()).then(function (result) {
 				self.model.currentCohortDefinition(null);
-				if (config.userAuthenticationEnabled) {
-					authApi.refreshToken();
-				}
 				document.location = "#/cohortdefinitions"
 			});
 		}
@@ -400,14 +397,10 @@ define(['knockout', 'text!./cohort-definition-manager.html',
 				result.expression = JSON.parse(result.expression);
 				var definition = new CohortDefinition(result);
 				var redirectWhenComplete = definition.id() != self.model.currentCohortDefinition().id();
-
-				var refreshTokenPromise = (redirectWhenComplete && config.userAuthenticationEnabled) ? authApi.refreshToken() : null;
-				$.when(refreshTokenPromise).done(function () {
-					self.model.currentCohortDefinition(definition);
-					if (redirectWhenComplete) {
-						document.location = "#/cohortdefinition/" + definition.id();
-					}
-				});
+				self.model.currentCohortDefinition(definition);
+				if (redirectWhenComplete) {
+					document.location = "#/cohortdefinition/" + definition.id();
+				}
 			});
 		}
 
@@ -431,10 +424,7 @@ define(['knockout', 'text!./cohort-definition-manager.html',
 
 			// reset view after save
 			cohortDefinitionAPI.copyCohortDefinition(self.model.currentCohortDefinition().id()).then(function (result) {
-				var refreshTokenPromise = config.userAuthenticationEnabled ? authApi.refreshToken() : null;
-				$.when(refreshTokenPromise).done(function () {
-					document.location = "#/cohortdefinition/" + result.id;
-				});
+				document.location = "#/cohortdefinition/" + result.id;
 			});
 		}
 
@@ -611,14 +601,12 @@ define(['knockout', 'text!./cohort-definition-manager.html',
       };
       var conceptSetItems = conceptSetUitls.toConceptSetItems(self.selectedConcepts());
       var conceptSetId;
-      var refreshTokenPromise = config.userAuthenticationEnabled ? authApi.refreshToken() : null;
       var itemsPromise = function(data) {
         conceptSetId = data.id;
         return conceptSetApi.saveConceptSetItems(data.id, conceptSetItems);
       };
       conceptSetApi.saveConceptSet(conceptSet)
         .then(itemsPromise)
-        .then(refreshTokenPromise);
     };
 
 		function createConceptSet() {

--- a/js/components/conceptset/conceptset-manager.js
+++ b/js/components/conceptset/conceptset-manager.js
@@ -568,8 +568,6 @@ define(['knockout',
 					}
 
 					var conceptSetItems = utils.toConceptSetItems(selectedConcepts);
-
-          var refreshTokenPromise = config.userAuthenticationEnabled ? authApi.refreshToken() : null;
 					var conceptSetId;
 					var itemsPromise = function(data) {
 						conceptSetId = data.id;
@@ -577,7 +575,6 @@ define(['knockout',
 					};
 					conceptSetAPI.saveConceptSet(conceptSet)
 						.then(itemsPromise)
-						.then(refreshTokenPromise)
 						.then(function(){
               document.location = '#/conceptset/' + conceptSetId + '/details';
               self.compareResults(null);

--- a/js/components/ir-manager.js
+++ b/js/components/ir-manager.js
@@ -180,11 +180,8 @@ define(['knockout',
 			iraAPI.saveAnalysis(self.selectedAnalysis()).then(function (analysis) {
 				self.selectedAnalysis(new IRAnalysisDefinition(analysis));
 				self.dirtyFlag(new ohdsiUtil.dirtyFlag(self.selectedAnalysis()));
-				var refreshTokenPromise = config.userAuthenticationEnabled ? authAPI.refreshToken() : null;
-				$.when(refreshTokenPromise).done(function () {
-					document.location =  `#/iranalysis/${analysis.id}`
-					self.loading(false);
-				});
+				document.location =  `#/iranalysis/${analysis.id}`
+				self.loading(false);
 			});
 		}
 		

--- a/js/components/plp-manager.js
+++ b/js/components/plp-manager.js
@@ -289,10 +289,7 @@ define(['knockout',
 
 		self.copy = function () {
 			plpAPI.copyPlp(self.patientLevelPredictionId()).then(function (result) {
-				var refreshTokenPromise = config.userAuthenticationEnabled ? authApi.refreshToken() : null;
-				$.when(refreshTokenPromise).done(function () {
-					document.location = "#/plp/" + result.analysisId;
-				});
+				document.location = "#/plp/" + result.analysisId;
 			});
 		}
 

--- a/js/components/role-details.js
+++ b/js/components/role-details.js
@@ -336,11 +336,9 @@ define(['knockout', 'text!./role-details.html', 'appConfig', 'ohdsi.util', 'data
                         saveUsers(),
                         savePermissions())
                     .done(function() {
-                        authApi.refreshToken().done(function() {
-                            self.roleDirtyFlag.reset();
-                            self.dirtyFlag.reset();
-                            document.location = '#/role/' + self.roleId();
-                        });
+                        self.roleDirtyFlag.reset();
+                        self.dirtyFlag.reset();
+                        document.location = '#/role/' + self.roleId();
                     })
                     .always(function() { self.loading(false); });
             });
@@ -358,7 +356,6 @@ define(['knockout', 'text!./role-details.html', 'appConfig', 'ohdsi.util', 'data
                 contentType: 'application/json',
                 error: authApi.handleAccessDenied,
                 success: function () {
-                    authApi.refreshToken();
                     var roles = self.model.roles().filter(function (role) {
                         return role.id != self.roleId();
                     });

--- a/js/components/user-bar.html
+++ b/js/components/user-bar.html
@@ -3,8 +3,8 @@
 	<div class="user-bar-container">
 		<a data-toggle="modal" data-target="#jobModal"><i data-bind="css: {pending: jobNotificationsPending}" class="fa fa-bell"></i></a>
 		<span data-bind="if:appConfig.userAuthenticationEnabled===true" style="display: inline-block;">
-			<div title="Sign In" data-bind="if: !isLoggedIn()"><span class="pipe">|</span><a data-toggle="modal" data-target="#myModal"><i class="fa fa-sign-in"></i>Sign In</a></div>
-			<div title="Sign Out" data-bind="if: isLoggedIn()"><span class="pipe">|</span><a data-toggle="modal" data-target="#myModal"><strong data-bind="text: authLogin()"></strong><i class="fa fa-user-circle fa-lg" aria-hidden="true"></i></a></div>
+			<div title="Sign In" data-bind="if: !isLoggedIn() || tokenExpired()"><span class="pipe">|</span><a data-toggle="modal" data-target="#myModal"><i class="fa fa-sign-in"></i>Sign In</a></div>
+			<div title="Sign Out" data-bind="if: isLoggedIn() && !tokenExpired()"><span class="pipe">|</span><a data-toggle="modal" data-target="#myModal"><strong data-bind="text: authLogin"></strong><i class="fa fa-user-circle fa-lg" aria-hidden="true"></i></a></div>
 		</span>
 	</div>
 </div>

--- a/js/components/user-bar.js
+++ b/js/components/user-bar.js
@@ -75,6 +75,7 @@ define(['knockout', 'text!./user-bar.html', 'appConfig', 'atlas-state'], functio
 
 		self.appConfig = appConfig;
 		self.token = authApi.token;
+    self.tokenExpired = authApi.tokenExpired;    
 		self.authLogin = authApi.subject;		
 		self.isLoggedIn = ko.computed(function () {
 			if (!self.token()) return null;

--- a/js/components/welcome.html
+++ b/js/components/welcome.html
@@ -4,11 +4,15 @@
 		<div data-bind="text: $component.status"></div>
 		-->
 		<div>
-			<div data-bind="if: !isLoggedIn()">
+			<div data-bind="if: !isLoggedIn() || tokenExpired()">
 				<!--
 				<span class="btn btn-sm btn-primary" data-bind="click: $component.signin">Login</span> with my
 				<select data-bind="options:$component.authProviders, optionsText:'name', value:$component.currentAuthProvider"></select> credentials
 				-->
+
+				<p class="text-danger" data-bind="if: isLoggedIn() && tokenExpired()">
+					Your session has expired. Please login again.
+				</p>
 
 				<div>
 					Sign In with:
@@ -35,7 +39,7 @@
 				<div data-bind="if: isBadCredentials() && !isInProgress()" class="error text-center"><span data-bind="text: errorMsg">Bad credentials</span></div>
 			</div>
 
-			<div data-bind="if: isLoggedIn()">
+			<div data-bind="if: isLoggedIn() && !tokenExpired()">
                 <div data-bind="text: $component.status"></div>
 				<span class="btn btn-sm btn-default" data-bind="click: $component.signout"><i class="fa fa-sign-out"></i> Sign Out</span>
 			</div>

--- a/js/components/welcome.js
+++ b/js/components/welcome.js
@@ -18,6 +18,7 @@ define(['knockout', 'text!./welcome.html', 'appConfig'], function (ko, view, app
                 ? expDate.toLocaleString()
                 : null;
         });
+        self.tokenExpired = authApi.tokenExpired;
         self.isLoggedIn = ko.computed(function () {
             if (!self.token()) return null;
             return authApi.isAuthenticated();

--- a/js/main.js
+++ b/js/main.js
@@ -196,14 +196,6 @@ requirejs(['bootstrap'], function () { // bootstrap must come first
 
 		ko.applyBindings(pageModel, document.getElementsByTagName('html')[0]);
 
-		// update access token
-		if (authApi.token()) {
-			var refreshTokenPromise = $.Deferred();
-			pageModel.initPromises.push(refreshTokenPromise);
-			authApi.refreshToken()
-				.always(refreshTokenPromise.resolve);
-		}
-
 		// establish base priorities for daimons
 		var evidencePriority = 0;
 		var vocabularyPriority = 0;


### PR DESCRIPTION
- Introduces centralized token refresh (on navigation to a new page)
- When the token is expired, displays login form with notification to let the user to re-login and continue working w/o loss of progress.

Closes https://github.com/OHDSI/Atlas/issues/677. Instead of https://github.com/OHDSI/Atlas/pull/678

(We cannot refresh token on ajax's "beforeSend", because some of ajaxs are called by setInterval and that would break session timeout functionality).

@chrisknoll , @johnSamilin 