### PR TITLE
Fixes from v2.4.2

### DIFF
--- a/js/components/home.html
+++ b/js/components/home.html
@@ -27,9 +27,9 @@
 	<div class="heading">Release Notes</div>
 	<div class="release-notes">
 		<div class="paddedWrapper">
-			<a href="https://github.com/OHDSI/Atlas/releases" target="_new">ATLAS Version 2.4.1 Release Notes</a>
+			<a href="https://github.com/OHDSI/Atlas/releases" target="_new">ATLAS Version 2.4.2 Release Notes</a>
 			<br/>
-			<a href="https://github.com/OHDSI/WebAPI/releases" target="_new">WebAPI Version 2.4.1 Release Notes</a>
+			<a href="https://github.com/OHDSI/WebAPI/releases" target="_new">WebAPI Version 2.4.2 Release Notes</a>
 		</div>
 
 		<div class="paddedWrapper">

--- a/js/main.js
+++ b/js/main.js
@@ -129,7 +129,7 @@ requirejs.config({
 		"cohortcomparison": "modules/cohortcomparison",
 		"r-manager": "components/r-manager",
 		"negative-controls": "components/negative-controls",
-		"atlascharts": "https://unpkg.com/@ohdsi/atlascharts@1.3.1/dist/atlascharts.min",
+		"atlascharts": "https://unpkg.com/@ohdsi/atlascharts@1.4.1/dist/atlascharts.min",
 		"jnj_chart": "jnj.chart", // scatterplot is not ported to separate library
 		"lodash": "lodash.4.15.0.full",
 		"lscache": "lscache.min",


### PR DESCRIPTION
These fixes from 2.4.2 include updating the home page version, and updating the reference to AtlasCharts.
