### PR TITLE
Cost & Util fixes & improvements

### DIFF
--- a/js/pages/cohort-definitions/cohort-definition-manager.js
+++ b/js/pages/cohort-definitions/cohort-definition-manager.js
@@ -1165,7 +1165,7 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 			}
 
 			generateHealthcareAnalyses () {
-				const analysisIds = this.checkedUtilReports().reduce((acc, ids) => [...acc, ...ids], []);
+				const analysisIds = this.utilReportOptions.reports.selectedOptions().reduce((acc, ids) => [...acc, ...ids], []);
 
 				this.generateAnalyses({
 					descr: 'the Cost and Utilization analyses',

--- a/js/pages/cohort-definitions/components/reporting/cost-utilization/base-report.js
+++ b/js/pages/cohort-definitions/components/reporting/cost-utilization/base-report.js
@@ -63,7 +63,7 @@ define(
         // Data
 
         this.filterList = ko.observableArray([]);
-        this.dataList = ko.observableArray();
+        this.dataList = ko.observableArray([]);
 
         // Charts formatters
 

--- a/js/pages/cohort-definitions/components/reporting/cost-utilization/persons-exposure.html
+++ b/js/pages/cohort-definitions/components/reporting/cost-utilization/persons-exposure.html
@@ -24,21 +24,25 @@
                 </tbody>
             </table>
         </div>
-        <ul class="nav nav-tabs">
-            <!-- ko foreach: Object.keys(tabLabels) -->
-            <li role="presentation" data-bind="click: function() { $component.currentTab($data); }, attr: {class: $component.currentTab() == $data ? 'active' : ''}">
-                <a data-bind="text: $component.tabLabels[$data]" />
-            </li>
-            <!-- /ko -->
-            <li data-bind="css: classes('save-csv-tab'), click: $component.saveAsCsv">
-                <a data-bind="css: classes('save-csv-link')">Save as CSV</a>
-            </li>
-        </ul>
-        <div class="tab-content">
-            <div role="tabpanel" data-bind="if: $component.currentTab() == $component.visualizationTab && !loading()">
-                <div data-bind="css: classes('chart-line')">
-                    <line-chart data-bind="css: $component.classes('chart')"
-                        params="{lineChart: {
+        <div data-bind="if: $component.dataList().length <= 0">
+            Detailed statistics are not available
+        </div>
+        <div data-bind="if: $component.dataList().length > 0">
+            <ul class="nav nav-tabs">
+                <!-- ko foreach: Object.keys(tabLabels) -->
+                <li role="presentation" data-bind="click: function() { $component.currentTab($data); }, attr: {class: $component.currentTab() == $data ? 'active' : ''}">
+                    <a data-bind="text: $component.tabLabels[$data]" />
+                </li>
+                <!-- /ko -->
+                <li data-bind="css: classes('save-csv-tab'), click: $component.saveAsCsv">
+                    <a data-bind="css: classes('save-csv-link')">Save as CSV</a>
+                </li>
+            </ul>
+            <div class="tab-content">
+                <div role="tabpanel" data-bind="if: $component.currentTab() == $component.visualizationTab && !loading()">
+                    <div data-bind="css: classes('chart-line')">
+                        <line-chart data-bind="css: $component.classes('chart')"
+                                    params="{lineChart: {
                             data: $component.personsChartData,
                             xLabel: '',
                             xFormat: $component.formatDate,
@@ -49,11 +53,11 @@
                             showLegend: false,
                             getTooltipBuilder: $component.getTooltipBuilder
                         }}"
-                    />
-                </div>
-                <div data-bind="css: classes('chart-line')">
-                    <line-chart data-bind="css: $component.classes('chart')"
-                                params="{lineChart: {
+                        />
+                    </div>
+                    <div data-bind="css: classes('chart-line')">
+                        <line-chart data-bind="css: $component.classes('chart')"
+                                    params="{lineChart: {
                             data: $component.totalExposureChartData,
                             xLabel: '',
                             xFormat: $component.formatDate,
@@ -64,11 +68,11 @@
                             showLegend: false,
                             getTooltipBuilder: $component.getTooltipBuilder
                         }}"
-                    />
-                </div>
-                <div data-bind="css: classes('chart-line')">
-                    <line-chart data-bind="css: $component.classes('chart')"
-                                params="{lineChart: {
+                        />
+                    </div>
+                    <div data-bind="css: classes('chart-line')">
+                        <line-chart data-bind="css: $component.classes('chart')"
+                                    params="{lineChart: {
                             data: $component.avgExposurePerPersonChartData,
                             xLabel: 'Period start',
                             xFormat: $component.formatDate,
@@ -79,11 +83,12 @@
                             showLegend: false,
                             getTooltipBuilder: $component.getTooltipBuilder
                         }}"
-                    />
+                        />
+                    </div>
                 </div>
-            </div>
-            <div role="tabpanel" data-bind="if: $component.currentTab() == $component.rawDataTab && !loading()">
-                <table-baseline-exposure params="{ dataList: dataList }"/>
+                <div role="tabpanel" data-bind="if: $component.currentTab() == $component.rawDataTab && !loading()">
+                    <table-baseline-exposure params="{ dataList: dataList }"/>
+                </div>
             </div>
         </div>
     </div>

--- a/js/pages/cohort-definitions/components/reporting/cost-utilization/visit-util.html
+++ b/js/pages/cohort-definitions/components/reporting/cost-utilization/visit-util.html
@@ -54,7 +54,10 @@
                 </tbody>
             </table>
         </div>
-        <div data-bind="css: classes('block')">
+        <div data-bind="if: $component.dataList().length <= 0, css: classes('block')">
+            Detailed statistics are not available
+        </div>
+        <div data-bind="if: $component.dataList().length > 0, css: classes('block')">
             <ul class="nav nav-tabs">
                 <!-- ko foreach: Object.keys(tabLabels) -->
                 <li role="presentation" data-bind="click: function() { $component.currentTab($data); }, attr: {class: $component.currentTab() == $data ? 'active' : ''}">

--- a/js/settings.js
+++ b/js/settings.js
@@ -114,7 +114,7 @@ const settingsObject = {
     "querystring": "https://cdnjs.cloudflare.com/ajax/libs/qs/6.5.1/qs.min",
 
     "bootstrap-select": "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.0-beta/js/bootstrap-select",
-    // "bootstrap-select-css": "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.0-beta/css/bootstrap-select.min",
+    "bootstrap-select-css": "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.0-beta/css/bootstrap-select.min",
     "less-js": "https://cdnjs.cloudflare.com/ajax/libs/less.js/3.0.1/less.min",
     "file-saver": "assets/FileSaver", //"https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.8/FileSaver.min",
     "numeral": "assets/numeral",


### PR DESCRIPTION
Fixed bootstrap-select styling
Fixed Cost & Util analyses selection modal
Do not display detailed data tables / charts when only summary is calculated for Cost & Util