### PR TITLE
Updating terminology in Circe UI.

### DIFF
--- a/js/components/cohortbuilder/components/CohortExpressionEditor.js
+++ b/js/components/cohortbuilder/components/CohortExpressionEditor.js
@@ -11,7 +11,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 		};
 
 		self.primaryCriteriaOptions = [{
-				text: "Add Condition Era Criteria",
+				text: "Add Condition Era",
 				selected: false,
 				description: "Find patients with specific diagosis era.",
 				action: function () {
@@ -21,7 +21,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Condition Occurrence Criteria",
+				text: "Add Condition Occurrence",
 				selected: false,
 				description: "Find patients with specific diagnoses.",
 				action: function () {
@@ -31,7 +31,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Death Criteria",
+				text: "Add Death",
 				selected: false,
 				description: "Find patients based on death.",
 				action: function () {
@@ -41,7 +41,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Device Exposure Criteria",
+				text: "Add Device Exposure",
 				selected: false,
 				description: "Find patients based on device exposure.",
 				action: function () {
@@ -51,7 +51,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Dose Era Criteria",
+				text: "Add Dose Era",
 				selected: false,
 				description: "Find patients with dose eras.",
 				action: function () {
@@ -61,7 +61,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Drug Era Criteria",
+				text: "Add Drug Era",
 				selected: false,
 				description: "Find patients with with exposure to drugs over time.",
 				action: function () {
@@ -71,7 +71,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Drug Exposure Criteria",
+				text: "Add Drug Exposure",
 				selected: false,
 				description: "Find patients with exposure to specific drugs or drug classes.",
 				action: function () {
@@ -81,7 +81,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Measurement Criteria",
+				text: "Add Measurement",
 				selected: false,
 				description: "Find patients based on Measurement.",
 				action: function () {
@@ -91,7 +91,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Observation Criteria",
+				text: "Add Observation",
 				selected: false,
 				description: "Find patients based on lab tests or other observations.",
 				action: function () {
@@ -101,7 +101,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Observation Period Criteria",
+				text: "Add Observation Period",
 				selected: false,
 				description: "Find patients based on Observation Period.",
 				action: function () {
@@ -111,7 +111,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Payer Plan Period Criteria",
+				text: "Add Payer Plan Period",
 				selected: false,
 				description: "Find patients based on Payer Plan Period.",
 				action: function () {
@@ -121,7 +121,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Procedure Occurrence Criteria",
+				text: "Add Procedure Occurrence",
 				selected: false,
 				description: "Find patients that experienced a specific procedure.",
 				action: function () {
@@ -131,7 +131,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Specimen Criteria",
+				text: "Add Specimen",
 				selected: false,
 				description: "Find patients based on Specimen.",
 				action: function () {
@@ -141,7 +141,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Visit Criteria",
+				text: "Add Visit",
 				selected: false,
 				description: "Find patients based on visit information.",
 				action: function () {
@@ -153,7 +153,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 		];
 
 		self.censorCriteriaOptions = [{
-				text: "Add Condition Era Criteria",
+				text: "Add Condition Era",
 				selected: false,
 				description: "Exit cohort based on diagosis era.",
 				action: function () {
@@ -163,7 +163,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Condition Occurrence Criteria",
+				text: "Add Condition Occurrence",
 				selected: false,
 				description: "Exit cohort based on  diagnoses.",
 				action: function () {
@@ -173,7 +173,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Death Criteria",
+				text: "Add Death",
 				selected: false,
 				description: "Exit cohort based on  death.",
 				action: function () {
@@ -183,7 +183,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Device Exposure Criteria",
+				text: "Add Device Exposure",
 				selected: false,
 				description: "Exit cohort based on  device exposure.",
 				action: function () {
@@ -193,7 +193,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Dose Era Criteria",
+				text: "Add Dose Era",
 				selected: false,
 				description: "Exit cohort based on dose eras.",
 				action: function () {
@@ -203,7 +203,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Drug Era Criteria",
+				text: "Add Drug Era",
 				selected: false,
 				description: "Exit cohort based on drugs over time.",
 				action: function () {
@@ -213,7 +213,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Drug Exposure Criteria",
+				text: "Add Drug Exposure",
 				selected: false,
 				description: "Exit cohort based on exposure to specific drugs or drug classes.",
 				action: function () {
@@ -223,7 +223,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Measurement Criteria",
+				text: "Add Measurement",
 				selected: false,
 				description: "Exit cohort based on Measurement.",
 				action: function () {
@@ -233,7 +233,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Observation Criteria",
+				text: "Add Observation",
 				selected: false,
 				description: "Exit cohort based on lab tests or other observations.",
 				action: function () {
@@ -243,7 +243,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Payer Plan Period Criteria",
+				text: "Add Payer Plan Period",
 				selected: false,
 				description: "Find patients based on Payer Plan Period.",
 				action: function () {
@@ -253,7 +253,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Procedure Occurrence Criteria",
+				text: "Add Procedure Occurrence",
 				selected: false,
 				description: "Exit cohort based on procedures.",
 				action: function () {
@@ -263,7 +263,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Specimen Criteria",
+				text: "Add Specimen",
 				selected: false,
 				description: "Find patients based on Specimen.",
 				action: function () {
@@ -273,7 +273,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 				}
 			},
 			{
-				text: "Add Visit Criteria",
+				text: "Add Visit",
 				selected: false,
 				description: "Exit cohort based on visit information.",
 				action: function () {
@@ -291,6 +291,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 		self.expression = params.expression;
 		self.options = options;
 
+		self.showCensorWindow = ko.observable(self.expression().CensorWindow().StartDate() || self.expression().CensorWindow().EndDate());
 		self.selectedInclusionRule = ko.observable(null);
 		self.selectedInclusionRuleIndex = null;
 
@@ -402,6 +403,7 @@ define(['knockout', 'jquery', '../options', '../CriteriaGroup', '../CriteriaType
 		self.inclusionRuleNavMinHeight = function() {
 			return Math.max(75, Math.min(550, self.expression().InclusionRules().length * 40) ) + "px";
 		}
+		
 
 		// Subscriptions
 

--- a/js/components/cohortbuilder/components/CohortExpressionEditorTemplate.html
+++ b/js/components/cohortbuilder/components/CohortExpressionEditorTemplate.html
@@ -2,11 +2,11 @@
 	<div class="modal-dialog" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
-				Initial event cohort
+				Cohort Entry Events
 			</div>
 			<div class="modal-body">
 				Events are recorded time-stamped observations for the persons, such as drug exposures, conditions, procedures, measurements and visits. All events have a start date and end date, though some events may have a start date and end date with the same value
-				(such as procedures or measurements). The event index date is set to be equal to the event start date.
+				(such as procedures or measurements).
 			</div>
 		</div>
 	</div>
@@ -16,7 +16,7 @@
 	<div class="modal-dialog" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
-				Additional Qualifying Inclusion Criteria
+				Inclusion Criteria
 			</div>
 			<div class="modal-body">
 				The qualifying cohort will be defined as all persons who have an initial event, satisfy the initial event inclusion criteria, and fulfill all additional qualifying inclusion criteria. Each qualifying inclusion criteria will be evaluated to determine the
@@ -26,37 +26,44 @@
 	</div>
 </div>
 
-<div class="modal" id="helpModalCensoringEvents" tabindex="-1 " role="dialog">
+<div class="modal" id="helpModalCohortExit" tabindex="-1 " role="dialog">
 	<div class="modal-dialog" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
-				Censoring Events
+				Cohort Exit
 			</div>
 			<div class="modal-body">
-				<p>
-					Censoring events are used to indicate when a person will exit the cohort due to one or more event triggers.
-				</p>
-				<p>
-					The first censoring event found after entering the cohort will be used to exit the cohort.
-				</p>
-				<p>
-					<i>Note: censoring events occurring prior to cohort entry will not exclude the person from the cohort.  Use inclusion criteria to filter the people that have the censoring event prior to index.</i>
-				</p>
+				<div>
+						For all qualifying events, there must be a specification of when each event ends presence in the cohort. 
+						By default, an event ends at the end of the observation period containing the qualifying initial event, 
+						but event end dates may be also be specified:
+				</div>
+				<div class="heading strong">Event End Dates</div>
+				<div>
+					The qualifying intial event can be set to end after a fixed time period relative to the event start or end date, 
+					or the end date can be based on the end of a continuous exposure to a set of drugs identified by a concept set.
+				</div>
+				<div class="heading strong">Censoring Events</div>
+				<div>
+					Criteria can be used to signal the end of an event.  If a censoring event is identified between a qualifying event's start and end date, 
+					the date of the censoring event will be used as the exit date.
+				</div>				
 			</div>
 		</div>
 	</div>
 </div>
 
+
 <div class="panel panel-primary cohort-definition-panel">
 	<div class="panel-heading">
-		Initial Event Cohort <i data-toggle="modal" data-target="#helpModalInitialEventCohort" class="fa fa-question-circle pull-right"></i>
+		Cohort Entry Events <i data-toggle="modal" data-target="#helpModalInitialEventCohort" class="fa fa-question-circle pull-right"></i>
 	</div>
 	<div class="panel-body">
 		<div class="criteriaGroup">
 			<div class="criteriaHeading">
 				<div class="row">
 					<div class="col-sm-4">
-						People having any of the following:
+						Events having any of the following criteria:
 					</div>
 					<div class="col-sm-8">
 						<div class="btn-group pull-right">
@@ -103,19 +110,19 @@
 		</div>
 		<div data-bind="with: expression">
 			<div data-bind="if: AdditionalCriteria">
-				<div><b>Initial event inclusion criteria:</b> From among the initial events, include:</div>
+				<div><b>Restrict intial events to:</b></div>
 				<criteria-group params="{expression: $data, group: AdditionalCriteria}"> </criteria-group>
-				<div style="padding: 3px 0px" data-bind="with: QualifiedLimit">Limit cohort of initial events to:
+				<div style="padding: 3px 0px" data-bind="with: QualifiedLimit">Limit initial events to:
 					<select data-bind="options: $component.options.resultLimitOptions,
 					optionsText: function(item) { return item.name },
 					optionsValue: 'id',
 					value: Type">
 					</select> per person.
 				</div>
-				<button class="btn btn-sm btn-danger" data-bind="click: function () { $component.removeAdditionalCriteria() }">Remove initial event inclusion criteria</button>
+				<button class="btn btn-sm btn-danger" data-bind="click: function () { $component.removeAdditionalCriteria() }">Remove initial event restriction</button>
 			</div>
 			<div data-bind="ifnot: AdditionalCriteria">
-				<button class="btn btn-sm btn-success" data-bind="click: function () { $component.addAdditionalCriteria() }">Add initial event inclusion criteria</button>
+				<button class="btn btn-sm btn-success" data-bind="click: function () { $component.addAdditionalCriteria() }">Restrict initial events</button>
 			</div>
 		</div>
 	</div>
@@ -124,7 +131,7 @@
 
 <div class="panel panel-primary cohort-definition-panel">
 	<div class="panel-heading">
-		Additional Qualifying Inclusion Criteria <i data-toggle="modal" data-target="#helpModalAdditionalQualifyingInclusionCritiera" class="fa fa-question-circle pull-right"></i>
+		Inclusion Criteria <i data-toggle="modal" data-target="#helpModalAdditionalQualifyingInclusionCritiera" class="fa fa-question-circle pull-right"></i>
 	</div>
 	<div class="panel-body">
 		<div data-bind="eventListener: [
@@ -136,7 +143,7 @@
 
 					<div style="position:absolute; top:0px; bottom:0px; left:0px; right:2px;">
 						<div>
-							<button class="btn btn-sm btn-success" data-bind="click: addInclusionRule">New qualifying inclusion criteria</button>
+							<button class="btn btn-sm btn-success" data-bind="click: addInclusionRule">New inclusion criteria</button>
 						</div>
 						<div>
 							<table style="width: 100%" class="inclusionRules">
@@ -162,13 +169,10 @@
 					<!-- ko if: $component.selectedInclusionRule() -->
 					<inclusion-rule-editor params="{IndexRule: expression, InclusionRule: selectedInclusionRule}"></inclusion-rule-editor>
 					<!-- /ko -->
-					<!-- ko ifnot: $component.selectedInclusionRule() -->
-					<div>Please select a qualifying inclusion criteria to edit.</div>
-					<!-- /ko -->							
 				</div>
 			</div>
 		</div>
-		<div style="padding-top: 3px" data-bind="with: expression().ExpressionLimit">Limit qualifying cohort to:
+		<div style="padding-top: 3px" data-bind="with: expression().ExpressionLimit">Limit qualifying events to:
 			<select data-bind="options: $component.options.resultLimitOptions,
 			optionsText: function(item) { return item.name },
 			optionsValue: 'id',
@@ -178,13 +182,15 @@
 	</div>
 </div>
 
-<end-strategy-editor params="strategy: $component.expression().EndStrategy, conceptSets: $component.expression().ConceptSets"></end-strategy-editor>
 
 <div class="panel panel-primary cohort-definition-panel">
 	<div class="panel-heading">
-		Censoring Events <i data-toggle="modal" data-target="#helpModalCensoringEvents" class="fa fa-question-circle pull-right"></i>
+		Cohort Exit <i data-toggle="modal" data-target="#helpModalCohortExit" class="fa fa-question-circle pull-right"></i>
 	</div>
 	<div class="panel-body">
+		<div class="heading strong">Event Persistence:</div>
+		<end-strategy-editor params="strategy: $component.expression().EndStrategy, conceptSets: $component.expression().ConceptSets"></end-strategy-editor>
+		<div class="heading strong">Censoring Events:</div>
 		<div class="criteriaGroup">
 			<div class="criteriaHeading">
 				<table>
@@ -195,7 +201,7 @@
 					<tbody>
 						<tr>
 							<td>
-								Exit Cohort based on the following:
+								Exit Cohort based on the following criteria:
 							</td>
 							<td>
 								<div class="btn-group pull-right">
@@ -240,35 +246,31 @@
 
 <div class="panel panel-primary cohort-definition-panel">
 	<div class="panel-heading">
-		Cohort Collapse Strategy
+		Cohort Eras
 	</div>
 	<div class="panel-body">
-		<div data-bind="with: expression().CollapseSettings">
+		<div data-bind="with: expression">
 			<ul>
 				<li>
 					Specify era collapse gap size:
-					<span contenteditable="true" class="numericInputField dropdown" data-bind="htmlValue: EraPad.numeric(), eventType: 'blur', ko_autocomplete: { value: EraPad, source: $component.options.dayOptions, minLength: 0, maxShowItems: 10, scroll: true }" />					days
+					<span contenteditable="true" class="numericInputField dropdown" data-bind="htmlValue: CollapseSettings.EraPad.numeric(), eventType: 'blur', ko_autocomplete: { value: CollapseSettings.EraPad, source: $component.options.dayOptions, minLength: 0, maxShowItems: 10, scroll: true }" /> days
 				</li>
+				<!-- ko if: $component.showCensorWindow -->
+				<li>
+					Left censor cohort start dates to <input placeholder="No Censoring" class="dateField" data-bind="datepicker: CensorWindow().StartDate, datepickerOptions: { defaultDate: new Date(), dateFormat: 'yy-mm-dd' }" /> <i data-bind="visible:CensorWindow().StartDate(),  click: () => CensorWindow().StartDate(null)" class="fa fa-times"></i>
+				</li>				
+				<li>
+					Right censor cohort end dates to <input placeholder="No Censoring" class="dateField" data-bind="datepicker: CensorWindow().EndDate, datepickerOptions: { defaultDate: new Date(), dateFormat: 'yy-mm-dd' }" /> <i data-bind="visible:CensorWindow().EndDate(),  click: () => CensorWindow().EndDate(null)" class="fa fa-times"></i>
+				</li>
+				<!-- /ko -->
+				<!-- ko ifnot: $component.showCensorWindow -->
+				<li>
+					<span class="linkish" data-bind="click: () => $component.showCensorWindow(!$component.showCensorWindow())"><i>add trimming options...</i></span>				
+				</li>
+				<!-- /ko -->
 			</ul>
 		</div>
-	</div>
-	<div class="panel-footer">
-		This strategy collapses events into eras of a continous period and eliminates the duplicate rows for the same subjects.
+
 	</div>
 </div>
 
-<div class="panel panel-primary cohort-definition-panel">
-	<div class="panel-heading">
-		Cohort Censor Window
-	</div>
-	<div class="panel-body">
-		<div class="row">
-			<div class="col-xs-12">
-				Drops all persons, who do no fall inside the censor window.
-			</div>
-			<div class="col-xs-12">
-				<period-input params="Period: expression().CensorWindow"></period-input>
-			</div>
-		</div>
-	</div>
-</div>

--- a/js/components/cohortbuilder/components/ConceptSetSelectorTemplate.html
+++ b/js/components/cohortbuilder/components/ConceptSetSelectorTemplate.html
@@ -3,8 +3,8 @@
 																																	{ event: 'mouseenter', selector: '.conceptset', callback: showConceptSetPreview},	
 																																	{ event: 'hidden.bs.dropdown', callback: hideConceptSetPreview}		
 																																]">
-		<button type="button" class="btn btn-success conceptset_edit" style="max-width:200px; overflow-x: hidden; text-overflow:ellipsis; white-space:nowrap" data-bind="text:conceptSetName, attr:{'title': conceptSetName}"></button>
-		<button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown">
+		<button type="button" class="btn btn-primary conceptset_edit" style="max-width:200px; overflow-x: hidden; text-overflow:ellipsis; white-space:nowrap" data-bind="text:conceptSetName, attr:{'title': conceptSetName}"></button>
+		<button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
 			<span class="caret"></span>  <!-- caret -->
 			<span class="sr-only" data-bind="text:conceptSetName"></span>
 		</button>

--- a/js/components/cohortbuilder/components/ConditionEra.js
+++ b/js/components/cohortbuilder/components/ConditionEra.js
@@ -99,15 +99,6 @@ define(['knockout', '../options', '../InputTypes/Range', '../CriteriaGroup', 'te
 			}
 		];
 
-		self.addCriterionSettings = {
-			selectText: "Add criteria attribute…",
-			height: 300,
-			actionOptions: self.addActions,
-			onAction: function (data) {
-				data.selectedData.action();
-			}
-		};
-
 		self.removeCriterion = function (propertyName) {
 			self.Criteria[propertyName](null);
 		}

--- a/js/components/cohortbuilder/components/ConditionEraTemplate.html
+++ b/js/components/cohortbuilder/components/ConditionEraTemplate.html
@@ -11,7 +11,7 @@
 				</td>
 				<td>
 					<div class="btn-group pull-right">
-						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add criteria attribute…<span class="caret"></span></button>
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add attribute...<span class="caret"></span></button>
 						<ul class="dropdown-menu" data-bind="foreach:$component.addActions">
 							<li><a data-bind="html:$component.formatOption($data), click:action" href="#"></a></li>
 						</ul>

--- a/js/components/cohortbuilder/components/ConditionOccurrence.js
+++ b/js/components/cohortbuilder/components/ConditionOccurrence.js
@@ -13,7 +13,7 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 		};
 
 		self.addActions = [{
-				text: "Add First Diagnosis Criteria",
+				text: "Add First Diagnosis",
 				selected: false,
 				description: "Limit Condition Occurrences to new diagnosis.",
 				action: function () {
@@ -22,7 +22,7 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 				}
 			},
 			{
-				text: "Add Age at Occurrence Criteria",
+				text: "Add Age at Occurrence",
 				selected: false,
 				description: "Filter Condition Occurrences by age at occurrence.",
 				action: function () {
@@ -31,7 +31,7 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 				}
 			},
 			{
-				text: "Add Gender Criteria",
+				text: "Add Gender",
 				selected: false,
 				description: "Filter Condition Occurrences based on Gender.",
 				action: function () {
@@ -41,7 +41,7 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 
 			},
 			{
-				text: "Add Condition Start Date Criteria",
+				text: "Add Condition Start Date",
 				selected: false,
 				description: "Filter Condition Occurrences by the Condition Start Date.",
 				action: function () {
@@ -52,7 +52,7 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 				}
 			},
 			{
-				text: "Add Condition End Date Criteria",
+				text: "Add Condition End Date",
 				selected: false,
 				description: "Filter Condition Occurrences  by the Condition End Date",
 				action: function () {
@@ -63,7 +63,7 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 				}
 			},
 			{
-				text: "Add Condition Type Criteria",
+				text: "Add Condition Type",
 				selected: false,
 				description: "Filter Condition Occurrences  by the Condition Type.",
 				action: function () {
@@ -72,7 +72,7 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 				}
 			},
 			{
-				text: "Add Visit Criteria",
+				text: "Add Visit",
 				selected: false,
 				description: "Filter Condition Occurrences based on visit occurrence of diagnosis.",
 				action: function () {
@@ -81,7 +81,7 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 				}
 			},
 			{
-				text: "Add Stop Reason Criteria",
+				text: "Add Stop Reason",
 				selected: false,
 				description: "Filter Condition Occurrences  by the Stop Reason.",
 				action: function () {
@@ -92,7 +92,7 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 				}
 			},
 			{
-				text: "Add Condition Source Concept Criteria",
+				text: "Add Condition Source Concept",
 				selected: false,
 				description: "Filter Condition Occurrences  by the Condition Source Concept.",
 				action: function () {
@@ -101,7 +101,7 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 				}
 			},
 			{
-				text: "Add Provider Specialty Criteria",
+				text: "Add Provider Specialty",
 				selected: false,
 				description: "Filter Condition Occurrences based on provider specialty.",
 				action: function () {
@@ -119,15 +119,6 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 				}
 			}
 		];
-
-		self.addCriterionSettings = {
-			selectText: "Add criteria attribute…",
-			height: 300,
-			actionOptions: self.addActions,
-			onAction: function (data) {
-				data.selectedData.action();
-			}
-		};
 
 		self.removeCriterion = function (propertyName) {
 			self.Criteria[propertyName](null);

--- a/js/components/cohortbuilder/components/ConditionOccurrenceTemplate.html
+++ b/js/components/cohortbuilder/components/ConditionOccurrenceTemplate.html
@@ -11,7 +11,7 @@
 				</td>
 				<td>
 					<div class="btn-group pull-right">
-						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add criteria attribute…<span class="caret"></span></button>
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add attribute...<span class="caret"></span></button>
 						<ul class="dropdown-menu" data-bind="foreach:$component.addActions">
 							<li><a data-bind="html:$component.formatOption($data), click:action" href="#"></a></li>
 						</ul>

--- a/js/components/cohortbuilder/components/CriteriaGroup.js
+++ b/js/components/cohortbuilder/components/CriteriaGroup.js
@@ -7,7 +7,7 @@ define(['knockout', '../CriteriaTypes', '../CriteriaGroup', '../InputTypes/Windo
 				'<div class="optionDescription">' + d.description + '</div>';
 		};
 		self.addCriteriaActions = [{
-				text: "Add Demographic Criteria",
+				text: "Add Demographic",
 				selected: false,
 				description: "Filter events based on demographic criteria.",
 				action: function () {
@@ -15,7 +15,7 @@ define(['knockout', '../CriteriaTypes', '../CriteriaGroup', '../InputTypes/Windo
 				}
 			},
 			{
-				text: "Add Condition Era Criteria",
+				text: "Add Condition Era",
 				selected: false,
 				description: "Find patients with specific condition era.",
 				action: function () {
@@ -23,7 +23,7 @@ define(['knockout', '../CriteriaTypes', '../CriteriaGroup', '../InputTypes/Windo
 				}
 			},
 			{
-				text: "Add Condition Occurrence Criteria",
+				text: "Add Condition Occurrence",
 				selected: false,
 				description: "Find patients with specific conditions.",
 				action: function () {
@@ -31,7 +31,7 @@ define(['knockout', '../CriteriaTypes', '../CriteriaGroup', '../InputTypes/Windo
 				}
 			},
 			{
-				text: "Add Death Criteria",
+				text: "Add Death",
 				selected: false,
 				description: "Find patients based on death.",
 				action: function () {
@@ -39,7 +39,7 @@ define(['knockout', '../CriteriaTypes', '../CriteriaGroup', '../InputTypes/Windo
 				}
 			},
 			{
-				text: "Add Device Exposure Criteria",
+				text: "Add Device Exposure",
 				selected: false,
 				description: "Find patients based on device exposure.",
 				action: function () {
@@ -47,7 +47,7 @@ define(['knockout', '../CriteriaTypes', '../CriteriaGroup', '../InputTypes/Windo
 				}
 			},
 			{
-				text: "Add Dose Era Criteria",
+				text: "Add Dose Era",
 				selected: false,
 				description: "Find patients with dose eras.",
 				action: function () {
@@ -55,7 +55,7 @@ define(['knockout', '../CriteriaTypes', '../CriteriaGroup', '../InputTypes/Windo
 				}
 			},
 			{
-				text: "Add Drug Era Criteria",
+				text: "Add Drug Era",
 				selected: false,
 				description: "Find patients with with drug eras.",
 				action: function () {
@@ -63,7 +63,7 @@ define(['knockout', '../CriteriaTypes', '../CriteriaGroup', '../InputTypes/Windo
 				}
 			},
 			{
-				text: "Add Drug Exposure Criteria",
+				text: "Add Drug Exposure",
 				selected: false,
 				description: "Find patients with exposure to specific drugs or drug classes.",
 				action: function () {
@@ -71,7 +71,7 @@ define(['knockout', '../CriteriaTypes', '../CriteriaGroup', '../InputTypes/Windo
 				}
 			},
 			{
-				text: "Add Measurement Criteria",
+				text: "Add Measurement",
 				selected: false,
 				description: "Find patients based on measurements.",
 				action: function () {
@@ -79,7 +79,7 @@ define(['knockout', '../CriteriaTypes', '../CriteriaGroup', '../InputTypes/Windo
 				}
 			},
 			{
-				text: "Add Observation Criteria",
+				text: "Add Observation",
 				selected: false,
 				description: "Find patients based on observations.",
 				action: function () {
@@ -87,7 +87,7 @@ define(['knockout', '../CriteriaTypes', '../CriteriaGroup', '../InputTypes/Windo
 				}
 			},
 			{
-				text: "Add Observation Period Criteria",
+				text: "Add Observation Period",
 				selected: false,
 				description: "Find patients based on observation periods.",
 				action: function () {
@@ -95,7 +95,7 @@ define(['knockout', '../CriteriaTypes', '../CriteriaGroup', '../InputTypes/Windo
 				}
 			},
 			{
-				text: "Add Payer Plan Period Criteria",
+				text: "Add Payer Plan Period",
 				selected: false,
 				description: "Find patients based on Payer Plan Period.",
 				action: function () {
@@ -103,7 +103,7 @@ define(['knockout', '../CriteriaTypes', '../CriteriaGroup', '../InputTypes/Windo
 				}
 			},
 			{
-				text: "Add Procedure Occurrence Criteria",
+				text: "Add Procedure Occurrence",
 				selected: false,
 				description: "Find patients that experienced a specific procedure.",
 				action: function () {
@@ -111,7 +111,7 @@ define(['knockout', '../CriteriaTypes', '../CriteriaGroup', '../InputTypes/Windo
 				}
 			},
 			{
-				text: "Add Specimen Criteria",
+				text: "Add Specimen",
 				selected: false,
 				description: "Find patients based on specimen.",
 				action: function () {
@@ -119,7 +119,7 @@ define(['knockout', '../CriteriaTypes', '../CriteriaGroup', '../InputTypes/Windo
 				}
 			},
 			{
-				text: "Add Visit Criteria",
+				text: "Add Visit",
 				selected: false,
 				description: "Find patients based on visit information.",
 				action: function () {

--- a/js/components/cohortbuilder/components/CustomEraStrategyTemplate.html
+++ b/js/components/cohortbuilder/components/CustomEraStrategyTemplate.html
@@ -1,10 +1,10 @@
 <div>
-	Cohort exit criteria based on the end of an era of persistent exposure to any drug within a defined concept set:  <br/>
+	<b>Continuous Exposure Persistence:</b><br/>
 	Specify a concept set that contains one or more drugs.  A drug era will be derived from all drug exposure events for any of the 
 	drugs within the concept set, using the specified persistence window as a maximum allowable gap in days between successive 
 	exposure events and adding a specified surveillance window to the final exposure event.  If no exposure event end date is 
 	provided, then an exposure event end date is inferred to be event start date + days supply in cases when days supply is 
-	available or event start date + 1 day otherwise. This cohort exit criteria assures that the cohort end date will be no greater 
+	available or event start date + 1 day otherwise. This event persistence assures that the cohort end date will be no greater 
 	than the drug era end date.
 </div>
 <div style="padding: 5px 0px">

--- a/js/components/cohortbuilder/components/DateOffsetStrategyTemplate.html
+++ b/js/components/cohortbuilder/components/DateOffsetStrategyTemplate.html
@@ -1,18 +1,18 @@
 <div>
-	Cohort exit criteria based on a fixed time period relative to initial event start or end date:<br/>
+	<b>Fixed Duration Persistence:</b><br/>
 </div>
 <div>
-	A cohort end date is derived from adding a number of days to be offset from the specified initial event date.  
-	If an offset is added to the initial event start date, all cohort episodes will have the same fixed duration 
-	(subject to further censoring from other cohort exit criteria).  If an offset is added to the initial event end date, 
-	persons in the cohort may have varying cohort duration times due to the varying durations of the initial events 
-	(such as eras of persistent drug exposure or visit length of stay).  This cohort exit criteria assures that the cohort 
+	The event end date is derived from adding a number of days to the event's start or end date.  
+	If an offset is added to the event's start date, all cohort episodes will have the same fixed duration 
+	(subject to further censoring).  If an offset is added to the event's end date, 
+	persons in the cohort may have varying cohort duration times due to the varying evevnt durations 
+	(such as eras of persistent drug exposure or visit length of stay).  This event persistence assures that the cohort 
 	end date will be no greater than the selected index event date, plus the days offset.
 </div>
 <div style="padding: 5px 0px">
 	<ul>
 		<li>
-			Initial event date to offset from:  <select data-bind="options: $component.fieldOptions, optionsText: 'name', optionsValue: 'id', value: strategy().DateField" />
+			Event date to offset from:  <select data-bind="options: $component.fieldOptions, optionsText: 'name', optionsValue: 'id', value: strategy().DateField" />
 		</li>
 		<li>
 			Number of days offset:  <span contenteditable="true" class="numericInputField dropdown" data-bind="htmlValue: strategy().Offset.numeric(), eventType:'blur', ko_autocomplete: { value: strategy().Offset, source: $component.options.dayOptions, minLength: 0, maxShowItems: 10, scroll: true }" /> days

--- a/js/components/cohortbuilder/components/Death.js
+++ b/js/components/cohortbuilder/components/Death.js
@@ -89,23 +89,7 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 					if (self.Criteria.CorrelatedCriteria() == null)
 						self.Criteria.CorrelatedCriteria(new CriteriaGroup(null, self.expression.ConceptSets));
 					break;
-					/*
-									case 8:
-										if (typeof self.Criteria.PriorEnrollDays() != "number")
-											self.Criteria.PriorEnrollDays(0);
-										break;
-									case 9:
-										if (typeof self.Criteria.AfterEnrollDays() != "number")
-											self.Criteria.AfterEnrollDays(0);
-										break;
-					*/
 			};
-			self.addCriterionSettings = {
-				selectText: "Add criteria attribute…",
-				height: 300,
-				actionOptions: self.addActions,
-				onAction: self.actionHandler
-			}
 		};
 
 		self.expression = ko.utils.unwrapObservable(params.expression);

--- a/js/components/cohortbuilder/components/DeathTemplate.html
+++ b/js/components/cohortbuilder/components/DeathTemplate.html
@@ -11,7 +11,7 @@
 				</td>
 				<td>
 					<div class="btn-group pull-right">
-						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add criteria attribute…<span class="caret"></span></button>
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add attribute...<span class="caret"></span></button>
 						<ul class="dropdown-menu" data-bind="foreach:$component.addActions">
 							<li><a data-bind="html:$component.formatOption($data), click:$component.actionHandler" href="#"></a></li>
 						</ul>

--- a/js/components/cohortbuilder/components/DemographicCriteria.js
+++ b/js/components/cohortbuilder/components/DemographicCriteria.js
@@ -69,15 +69,6 @@ define(['knockout', '../options', '../InputTypes/Range', 'text!./DemographicCrit
 			}
 		];
 
-		self.addCriterionSettings = {
-			selectText: "Add criteria attribute…",
-			height: 250,
-			actionOptions: self.addActions,
-			onAction: function (data) {
-				data.selectedData.action();
-			}
-		};
-
 		self.removeCriterion = function (propertyName) {
 			self.Criteria[propertyName](null);
 		}

--- a/js/components/cohortbuilder/components/DemographicCriteriaTemplate.html
+++ b/js/components/cohortbuilder/components/DemographicCriteriaTemplate.html
@@ -6,7 +6,7 @@
 			<tr>
 				<td colspan="2">
 					<div class="btn-group pull-right">
-						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add criteria attribute…<span class="caret"></span></button>
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add attribute...<span class="caret"></span></button>
 						<ul class="dropdown-menu" data-bind="foreach:$component.addActions">
 							<li><a data-bind="html:$component.formatOption($data), click:action" href="#"></a></li>
 						</ul>

--- a/js/components/cohortbuilder/components/DeviceExposure.js
+++ b/js/components/cohortbuilder/components/DeviceExposure.js
@@ -167,13 +167,6 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 			}
 		}
 
-		self.addCriterionSettings = {
-			selectText: "Add criteria attribute…",
-			height: 300,
-			actionOptions: self.addActions,
-			onAction: self.actionHandler
-		};
-
 		self.expression = ko.utils.unwrapObservable(params.expression);
 		self.Criteria = params.criteria.DeviceExposure;
 		self.options = options;

--- a/js/components/cohortbuilder/components/DeviceExposureTemplate.html
+++ b/js/components/cohortbuilder/components/DeviceExposureTemplate.html
@@ -11,7 +11,7 @@
 				</td>
 				<td>
 					<div class="btn-group pull-right">
-						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add criteria attribute…<span class="caret"></span></button>
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add attribute...<span class="caret"></span></button>
 						<ul class="dropdown-menu" data-bind="foreach:$component.addActions">
 							<li><a data-bind="html:$component.formatOption($data), click:$component.actionHandler" href="#"></a></li>
 						</ul>

--- a/js/components/cohortbuilder/components/DoseEra.js
+++ b/js/components/cohortbuilder/components/DoseEra.js
@@ -106,15 +106,6 @@ define(['knockout', '../options', '../InputTypes/Range', '../CriteriaGroup', 'te
 			}
 		];
 
-		self.addCriterionSettings = {
-			selectText: "Add criteria attribute…",
-			height: 300,
-			actionOptions: self.addActions,
-			onAction: function (data) {
-				data.selectedData.action();
-			}
-		};
-
 		self.removeCriterion = function (propertyName) {
 			self.Criteria[propertyName](null);
 		}

--- a/js/components/cohortbuilder/components/DoseEraTemplate.html
+++ b/js/components/cohortbuilder/components/DoseEraTemplate.html
@@ -11,7 +11,7 @@
 				</td>
 				<td>
 					<div class="btn-group pull-right">
-						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add criteria attribute…<span class="caret"></span></button>
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add attribute...<span class="caret"></span></button>
 						<ul class="dropdown-menu" data-bind="foreach:$component.addActions">
 							<li><a data-bind="html:$component.formatOption($data), click:action" href="#"></a></li>
 						</ul>

--- a/js/components/cohortbuilder/components/DrugEra.js
+++ b/js/components/cohortbuilder/components/DrugEra.js
@@ -97,15 +97,6 @@ define(['knockout', '../options', '../InputTypes/Range', '../CriteriaGroup', 'te
 			}
 		];
 
-		self.addCriterionSettings = {
-			selectText: "Add criteria attribute…",
-			height: 300,
-			actionOptions: self.addActions,
-			onAction: function (data) {
-				data.selectedData.action();
-			}
-		};
-
 		self.removeCriterion = function (propertyName) {
 			self.Criteria[propertyName](null);
 		}

--- a/js/components/cohortbuilder/components/DrugEraTemplate.html
+++ b/js/components/cohortbuilder/components/DrugEraTemplate.html
@@ -11,7 +11,7 @@
 				</td>
 				<td>
 					<div class="btn-group pull-right">
-						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add criteria attribute…<span class="caret"></span></button>
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add attribute...<span class="caret"></span></button>
 						<ul class="dropdown-menu" data-bind="foreach:$component.addActions">
 							<li><a data-bind="html:$component.formatOption($data), click:action" href="#"></a></li>
 						</ul>

--- a/js/components/cohortbuilder/components/DrugExposure.js
+++ b/js/components/cohortbuilder/components/DrugExposure.js
@@ -235,13 +235,6 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 			}
 		}
 
-		self.addCriterionSettings = {
-			selectText: "Add criteria attribute…",
-			height: 300,
-			actionOptions: self.addActions,
-			onAction: self.actionHandler
-		};
-
 		self.expression = ko.utils.unwrapObservable(params.expression);
 		self.Criteria = params.criteria.DrugExposure;
 		self.options = options;

--- a/js/components/cohortbuilder/components/DrugExposureTemplate.html
+++ b/js/components/cohortbuilder/components/DrugExposureTemplate.html
@@ -11,7 +11,7 @@
 				</td>
 				<td>
 					<div class="btn-group pull-right">
-						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add criteria attribute…<span class="caret"></span></button>
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add attribute...<span class="caret"></span></button>
 						<ul class="dropdown-menu" data-bind="foreach:$component.addActions">
 							<li><a data-bind="html:$component.formatOption($data), click:$component.actionHandler" href="#"></a></li>
 						</ul>

--- a/js/components/cohortbuilder/components/EndStrategyEditorTemplate.html
+++ b/js/components/cohortbuilder/components/EndStrategyEditorTemplate.html
@@ -1,41 +1,14 @@
-<div class="modal" id="helpModalCohortExitCriteria" tabindex="-1 " role="dialog">
-	<div class="modal-dialog" role="document">
-		<div class="modal-content">
-			<div class="modal-header">
-				Cohort Exit Criteria
-			</div>
-			<div class="modal-body">
-				For all persons who entered the cohort, there must be a specification of when each person exits the cohort. A person must exit the cohort at the end of the observation period spanning the qualifying initial event start date, but additional cohort exit
-				criteria may be also considered.
-			</div>
-		</div>
-	</div>
+<div>
+	Event will persist until: 
+	<select data-bind="options: $component.strategyOptions,
+		optionsText: function(item) { return item.text },
+		optionsValue: 'name',
+		value: strategyType">
+	</select>
 </div>
-
-<div class="panel panel-primary cohort-definition-panel">
-	<div class="panel-heading">
-		Cohort Exit Criteria <i data-toggle="modal" data-target="#helpModalCohortExitCriteria" class="fa fa-question-circle pull-right"></i>
-	</div>
-	<div class="panel-body">
-		<div data-bind="if: ko.utils.unwrapObservable(strategy) == null">
-			<div>
-				Add a cohort exit criteria:
-			</div>
-			<ul>
-				<li><span class="linkish" data-bind="click: function() { setStrategy('dateOffset'); }">Based on a fixed time period relative to initial event start or end date</span></li>
-				<li><span class="linkish" data-bind="click: function() { setStrategy('customEra'); }">Based on the end of an era of persistent exposure to any drug within a defined concept set</span></li>
-			</ul>
-			<div>
-				The minimum date from amongst the selected cohort exit criteria occurring after the cohort entry date will be selected as the end date for the person's episode.
-			</div>
-		</div>
-
-		<div data-bind="if: ko.utils.unwrapObservable(strategy) != null">
-			<div data-bind="component: {
-	name: strategyComponentName,
-	params: {strategy: strategy, conceptSets: conceptSets }
+<div data-bind="if: ko.utils.unwrapObservable(strategy) != null">
+	<div data-bind="component: {
+name: strategyComponentName,
+params: {strategy: strategy, conceptSets: conceptSets }
 }"></div>
-			<button class="btn btn-sm btn-danger" data-bind="click: function () { $component.clearStrategy() }">Remove Cohort Exit Criteria</button>
-		</div>
-	</div>
 </div>

--- a/js/components/cohortbuilder/components/Measurement.js
+++ b/js/components/cohortbuilder/components/Measurement.js
@@ -195,15 +195,6 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 			}
 		];
 
-		self.addCriterionSettings = {
-			selectText: "Add criteria attribute…",
-			height: 300,
-			actionOptions: self.addActions,
-			onAction: function (data) {
-				data.selectedData.action();
-			}
-		};
-
 		self.removeCriterion = function (propertyName) {
 			self.Criteria[propertyName](null);
 		}

--- a/js/components/cohortbuilder/components/MeasurementTemplate.html
+++ b/js/components/cohortbuilder/components/MeasurementTemplate.html
@@ -11,7 +11,7 @@
 				</td>
 				<td>
 					<div class="btn-group pull-right">
-						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add criteria attribute…<span class="caret"></span></button>
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add attribute...<span class="caret"></span></button>
 						<ul class="dropdown-menu" data-bind="foreach:$component.addActions">
 							<li><a data-bind="html:$component.formatOption($data), click:action" href="#"></a></li>
 						</ul>

--- a/js/components/cohortbuilder/components/Observation.js
+++ b/js/components/cohortbuilder/components/Observation.js
@@ -154,15 +154,6 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 			}
 		];
 
-		self.addCriterionSettings = {
-			selectText: "Add criteria attribute…",
-			height: 300,
-			actionOptions: self.addActions,
-			onAction: function (data) {
-				data.selectedData.action();
-			}
-		};
-
 		self.expression = ko.utils.unwrapObservable(params.expression);
 		self.Criteria = params.criteria.Observation;
 		self.options = options;

--- a/js/components/cohortbuilder/components/ObservationPeriod.js
+++ b/js/components/cohortbuilder/components/ObservationPeriod.js
@@ -108,15 +108,6 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Period',
 			}
 		];
 
-		self.addCriterionSettings = {
-			selectText: "Add criteria attribute…",
-			height: 300,
-			actionOptions: self.addActions,
-			onAction: function (data) {
-				data.selectedData.action();
-			}
-		};
-
 		self.removeCriterion = function (propertyName) {
 			self.Criteria[propertyName](null);
 		}

--- a/js/components/cohortbuilder/components/ObservationPeriodTemplate.html
+++ b/js/components/cohortbuilder/components/ObservationPeriodTemplate.html
@@ -10,7 +10,7 @@
 				</td>
 				<td>
 					<div class="btn-group pull-right">
-						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add criteria attribute…<span class="caret"></span></button>
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add attribute...<span class="caret"></span></button>
 						<ul class="dropdown-menu" data-bind="foreach:$component.addActions">
 							<li><a data-bind="html:$component.formatOption($data), click:action" href="#"></a></li>
 						</ul>

--- a/js/components/cohortbuilder/components/ObservationTemplate.html
+++ b/js/components/cohortbuilder/components/ObservationTemplate.html
@@ -11,7 +11,7 @@
 				</td>
 				<td>
 					<div class="btn-group pull-right">
-						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add criteria attribute…<span class="caret"></span></button>
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add attribute...<span class="caret"></span></button>
 						<ul class="dropdown-menu" data-bind="foreach:$component.addActions">
 							<li><a data-bind="html:$component.formatOption($data), click:action" href="#"></a></li>
 						</ul>

--- a/js/components/cohortbuilder/components/PayerPlanPeriodTemplate.html
+++ b/js/components/cohortbuilder/components/PayerPlanPeriodTemplate.html
@@ -10,7 +10,7 @@
 				</td>
 				<td>
 					<div class="btn-group pull-right">
-						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add criteria attribute…<span class="caret"></span></button>
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add attribute...<span class="caret"></span></button>
 						<ul class="dropdown-menu" data-bind="foreach:$component.addActions">
 							<li><a data-bind="html:$component.formatOption($data), click:action" href="#"></a></li>
 						</ul>

--- a/js/components/cohortbuilder/components/ProcedureOccurrence.js
+++ b/js/components/cohortbuilder/components/ProcedureOccurrence.js
@@ -150,13 +150,6 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 			}
 		};
 
-		self.addCriterionSettings = {
-			selectText: "Add criteria attribute…",
-			height: 300,
-			actionOptions: self.addActions,
-			onAction: self.actionHandler
-		};
-
 		self.expression = ko.utils.unwrapObservable(params.expression);
 		self.Criteria = params.criteria.ProcedureOccurrence;
 		self.options = options;

--- a/js/components/cohortbuilder/components/ProcedureOccurrenceTemplate.html
+++ b/js/components/cohortbuilder/components/ProcedureOccurrenceTemplate.html
@@ -11,7 +11,7 @@
 				</td>
 				<td>
 					<div class="btn-group pull-right">
-						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add criteria attribute…<span class="caret"></span></button>
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add attribute...<span class="caret"></span></button>
 						<ul class="dropdown-menu" data-bind="foreach:$component.addActions">
 							<li><a data-bind="html:$component.formatOption($data), click:$component.actionHandler" href="#"></a></li>
 						</ul>

--- a/js/components/cohortbuilder/components/Specimen.js
+++ b/js/components/cohortbuilder/components/Specimen.js
@@ -116,15 +116,6 @@ define(['knockout', '../options', '../InputTypes/Range', '../InputTypes/Text', '
 			}
 		];
 
-		self.addCriterionSettings = {
-			selectText: "Add criteria attribute…",
-			height: 300,
-			actionOptions: self.addActions,
-			onAction: function (data) {
-				data.selectedData.action();
-			}
-		};
-
 		self.removeCriterion = function (propertyName) {
 			self.Criteria[propertyName](null);
 		}

--- a/js/components/cohortbuilder/components/SpecimenTemplate.html
+++ b/js/components/cohortbuilder/components/SpecimenTemplate.html
@@ -11,7 +11,7 @@
 				</td>
 				<td>
 					<div class="btn-group pull-right">
-						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add criteria attribute…<span class="caret"></span></button>
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add attribute...<span class="caret"></span></button>
 						<ul class="dropdown-menu" data-bind="foreach:$component.addActions">
 							<li><a data-bind="html:$component.formatOption($data), click:action" href="#"></a></li>
 						</ul>

--- a/js/components/cohortbuilder/components/VisitOccurrence.js
+++ b/js/components/cohortbuilder/components/VisitOccurrence.js
@@ -111,15 +111,6 @@ define(['knockout', '../options', '../InputTypes/Range', '../CriteriaGroup', 'te
 			}
 		];
 
-		self.addCriterionSettings = {
-			selectText: "Add criteria attribute…",
-			height: 300,
-			actionOptions: self.addActions,
-			onAction: function (data) {
-				data.selectedData.action();
-			}
-		};
-
 		self.expression = ko.utils.unwrapObservable(params.expression);
 		self.Criteria = params.criteria.VisitOccurrence;
 		self.options = options;

--- a/js/components/cohortbuilder/components/VisitOccurrenceTemplate.html
+++ b/js/components/cohortbuilder/components/VisitOccurrenceTemplate.html
@@ -11,7 +11,7 @@
 				</td>
 				<td>
 					<div class="btn-group pull-right">
-						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add criteria attribute…<span class="caret"></span></button>
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus"></i> Add attribute...<span class="caret"></span></button>
 						<ul class="dropdown-menu" data-bind="foreach:$component.addActions">
 							<li><a data-bind="html:$component.formatOption($data), click:action" href="#"></a></li>
 						</ul>

--- a/js/components/cohortbuilder/css/builder.css
+++ b/js/components/cohortbuilder/css/builder.css
@@ -11,6 +11,7 @@ div.criteriaGroup {
 	/* border-right: solid 0px black; */
 	/* border-bottom: solid 1px #ccc; */
 }
+
 div.criteriaGroup div.criteriaHeading {
 	margin-bottom: 5px;
 	/* position: absolute; */

--- a/js/pages/cohort-definitions/cohort-definition-manager.html
+++ b/js/pages/cohort-definitions/cohort-definition-manager.html
@@ -45,7 +45,7 @@
 				<a>Export</a>
 			</li>
 			<li role="presentation" data-bind="css: { active: $component.tabMode() === 'warnings' }, click: function(){ $component.tabMode('warnings'); } ">
-				<a data-bind="attr: { class: warningClass }">Warnings <span class="badge" data-bind="text: warningsTotals, visible: warningsTotals() > 0"></span></a>
+				<a data-bind="attr: { class: warningClass }">Messages <span class="badge" data-bind="text: warningsTotals, visible: warningsTotals() > 0"></span></a>
 			</li>
 		</ul>
 		<div class="tab-content">

--- a/js/styles/atlas.css
+++ b/js/styles/atlas.css
@@ -80,6 +80,10 @@ body {
   margin: 12px 0px 3px 0px;
 }
 
+.heading.strong {
+  font-weight: bold;
+}
+
 .subheading {
   font-size: 12px;
   color: #000;


### PR DESCRIPTION
Combined UI groups into 4 main sections: Initial Events, Inclusion Criteria, Cohort Exit and Cohort Eras.

Changed exit strategy selector to a dropdown.
Hide Censor Window by default.
Removed 'Criteria' from dropdowns and action buttons.
Renamed 'Warnings' to 'Messages' tab.

Removed 'Please Select' messaging.
Changed concept set selector to blue to match other drop-downs.
Updated help text.