### PR TITLE
Fixes #932

### DIFF
--- a/js/components/terms-and-conditions/terms-and-conditions.js
+++ b/js/components/terms-and-conditions/terms-and-conditions.js
@@ -26,7 +26,7 @@ define([
       super(params);
       this.isModalShown = ko.pureComputed({
         read: () => {
-          return authApi.isAuthenticated() && !this.isAccepted();
+          return authApi.isAuthenticated() && appConfig.enableTermsAndConditions && !this.isAccepted();
         },
         write: (value) => {
           return false;

--- a/js/config/app.js
+++ b/js/config/app.js
@@ -96,6 +96,7 @@ define(function () {
       "splicer": "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid={@id}"
     },
   };
+  appConfig.enableTermsAndConditions = true;
 	
 	appConfig.webAPIRoot = appConfig.api.url;
 	


### PR DESCRIPTION
Enables the ability to override if the terms & condition modal is shown. By default, it will be set to `true` in the base configuration file.