### PR TITLE
Fix source database connection check error in Microsoft SQL Server

### DIFF
--- a/js/pages/configuration/sources/source-manager.js
+++ b/js/pages/configuration/sources/source-manager.js
@@ -135,7 +135,7 @@ define([
 
       this.options.dialectOptions = [
         { name: 'PostgreSQL', id: 'postgresql' },
-        { name: 'SQL server', id: 'sqlserver' },
+        { name: 'SQL server', id: 'sql server' },
         { name: 'Oracle', id: 'oracle' },
         { name: 'Amazon Redshift', id: 'redshift' },
         { name: 'Google BigQuery', id: 'bigquery' },


### PR DESCRIPTION
When adding a source for MS SQL on the Configuration page, the SOURCE_DIALECT column of the source table is loaded into sqlserver, which prevents the connection from being made properly. (The correct DIALECT is sql server)