### PR TITLE
Create separate source flag for sources configured with CEMResults

### DIFF
--- a/js/components/evidence/components/negative-controls.js
+++ b/js/components/evidence/components/negative-controls.js
@@ -238,7 +238,7 @@ define(['knockout',
 				var evidenceSources = [];
 
 				$.each(sharedState.sources(), function (i, source) {
-					if (source.hasEvidence) {
+					if (source.hasEvidence && source.hasCEMResults) {
 						var sourceInfo = {};
 						sourceInfo.sourceId = ko.observable(source.sourceId);
 						sourceInfo.sourceKey = ko.observable(source.sourceKey);

--- a/js/components/evidence/components/negative-controls.js
+++ b/js/components/evidence/components/negative-controls.js
@@ -224,10 +224,10 @@ define(['knockout',
 						conceptDomainId = "Drug";
 						targetDomainId = "Condition";
 					} else {
-						this.conceptSetValidText("Your saved concepts come from multiple Domains (Condition, Drug). The concept set must contain ONLY conditions OR drugs in order to explore evidence.");
+						this.conceptSetValidText("Your saved concepts come from multiple domains or from a domain outside of conditions or drugs. The concept set must contain ONLY conditions OR drugs in order to explore evidence.");
 					}
 				} else {
-					this.conceptSetValidText("You must define a concept set with drugs found in the RxNorm vocbulary at the Ingredient class level OR Conditions from SNOMED. The concept set must contain ONLY conditions OR drugs in order to explore evidence.");
+					this.conceptSetValidText("You must define a concept set with drugs found in the RxNorm vocabulary at the Ingredient class level OR Conditions from SNOMED. The concept set must contain ONLY conditions OR drugs in order to explore evidence.");
 				}
 				this.conceptSetValid(conceptSetValid);
 				this.conceptDomainId(conceptDomainId);

--- a/js/services/SourceAPI.js
+++ b/js/services/SourceAPI.js
@@ -107,6 +107,7 @@ define(function (require, exports) {
       source.hasVocabulary = false;
       source.hasEvidence = false;
       source.hasResults = false;
+      source.hasCEMResults = false;
       source.hasCDM = false;
       source.vocabularyUrl = '';
       source.evidenceUrl = '';
@@ -141,7 +142,7 @@ define(function (require, exports) {
 
         // evaluate cem daimons
         if (daimon.daimonType == 'CEMResults') {
-          source.hasResults = true;
+          source.hasCEMResults = true;
           source.evidenceUrl = config.api.url + 'evidence/' + source.sourceKey + '/';
         }
 


### PR DESCRIPTION
Aims to close #1064; I had re-used the `hasResults` flag on the CEM source which was causing problems with the record count display.

Also revised the warning message when exploring evidence per OHDSI/WebAPI#397