### PR TITLE
Concept record count fixes and closing concept set fix

### DIFF
--- a/js/pages/concept-sets/concept-manager.js
+++ b/js/pages/concept-sets/concept-manager.js
@@ -341,7 +341,7 @@ define([
 		}
 
 		onRouterParamsChanged({ conceptId }) {			
-			if (conceptId !== this.currentConceptId) {
+			if (conceptId !== this.currentConceptId && conceptId !== undefined) {
 				if (this.model.currentConceptMode() == 'recordcounts') {
 					this.loadRecordCounts();
 				}
@@ -354,7 +354,7 @@ define([
 			const sourceData = [];
 			for (const source of sources) {
 				const { data } = await httpService.doPost(`${source.resultsUrl}conceptRecordCount`, [this.currentConceptId]);
-				const recordCountObject = Object.values(data[0])[0];
+				const recordCountObject = data.length > 0 ? Object.values(data[0])[0] : null;
 				if (recordCountObject) {
 					sourceData.push({
 						sourceName: source.sourceName,

--- a/js/pages/concept-sets/conceptset-manager.html
+++ b/js/pages/concept-sets/conceptset-manager.html
@@ -1,3 +1,4 @@
+<!-- ko if: currentConceptSet() != null -->
 <heading-title params="name: currentConceptSet().name, icon: 'shopping-cart', theme: 'dark'"></heading-title>
 
 <div data-bind="css: classes()">
@@ -176,3 +177,4 @@
     </div>
   </div>
 </atlas-modal>
+<!-- /ko -->


### PR DESCRIPTION
Please test this with OHDSI/WebAPI#716. Aims to correct errors observed when testing that PR whereby concepts that have no records in a CDM, the concept record count tab fails to load. Furthermore, when navigating away from a concept page to another section of the application (`onRouterParamsChanged`), an exception was thrown so I added in a check to determine if a valid conceptId is defined.