### PR TITLE
Concept set fixes

### DIFF
--- a/js/Model.js
+++ b/js/Model.js
@@ -366,8 +366,7 @@ define(
 			// for the current selected concepts:
 			// update the export panel
 			// resolve the included concepts and update the include concept set identifier list
-			resolveConceptSetExpression() {
-				this.resolvingConceptSetExpression(true);
+			resolveConceptSetExpression(resolveAgainstServer = true) {
         this.includedConcepts.removeAll();
         this.includedSourcecodes.removeAll();
 				var conceptSetExpression = { "items": sharedState.selectedConcepts() };
@@ -379,7 +378,7 @@ define(
 				}
 				this.currentConceptIdentifierList(conceptIdentifierList.join(','));
 
-				return this.resolveConceptSetExpressionSimple(conceptSetExpression);
+				return resolveAgainstServer ? this.resolveConceptSetExpressionSimple(conceptSetExpression) : null;
 			}
 
 			resolveConceptSetExpressionSimple(expression, success) {
@@ -391,6 +390,7 @@ define(
 							this.conceptSetInclusionCount(info.length);
 							this.resolvingConceptSetExpression(false);
 						};
+				this.resolvingConceptSetExpression(true);
 				const resolvingPromise = httpService.doPost(sharedState.vocabularyUrl() + 'resolveConceptSetExpression', expression);
 				resolvingPromise.then(callback);
 				resolvingPromise.catch((err) => {
@@ -821,7 +821,7 @@ define(
 			clearConceptSet() {
 				this.currentConceptSet(null);
 				sharedState.clearSelectedConcepts();
-				this.resolveConceptSetExpression();
+				this.resolveConceptSetExpression(false);
 				this.currentConceptSetDirtyFlag().reset();
 			}
 

--- a/js/components/circe/components/CohortConceptSetBrowser.js
+++ b/js/components/circe/components/CohortConceptSetBrowser.js
@@ -6,7 +6,7 @@ define(['knockout', 'text!./CohortConceptSetBrowserTemplate.html', 'services/Voc
 			// Default functionality
 			VocabularyProvider.getConceptSetExpression(conceptSet.id, self.selectedSource()
 					.url)
-				.done(function (result) {
+				.then((result) => {
 					var newId = self.cohortConceptSets()
 						.length > 0 ? Math.max.apply(null, self.cohortConceptSets()
 							.map(function (d) {
@@ -27,7 +27,7 @@ define(['knockout', 'text!./CohortConceptSetBrowserTemplate.html', 'services/Voc
 						status: 'Success'
 					});
 				})
-				.fail(function (err) {
+				.catch((err) => {
 					console.log(err);
 				});
 		}

--- a/js/pages/concept-sets/components/tabs/conceptset-compare.js
+++ b/js/pages/concept-sets/components/tabs/conceptset-compare.js
@@ -275,7 +275,7 @@ define([
 			conceptSet.id = 0;
 			conceptSet.name = this.compareNewConceptSetName;
 			const selectedConcepts = [];
-			$.each(dtItems, (item) => {
+			$.each(dtItems, (index, item) => {
 				const concept = {
 					CONCEPT_CLASS_ID: item.conceptClassId,
 					CONCEPT_CODE: item.conceptCode,

--- a/js/pages/concept-sets/concept-manager.html
+++ b/js/pages/concept-sets/concept-manager.html
@@ -84,7 +84,7 @@
 											{ title: 'Class', data: 'CONCEPT_CLASS_ID' },
 											{ title: 'RC', data: 'RECORD_COUNT'},
 											{ title: 'DRC', data: 'DESCENDANT_RECORD_COUNT'},
-											{ title: 'Distance', data: function (d) { return Math.max.apply(Math, d.RELATIONSHIPS.map(function (o) {return o.RELATIONSHIP_DISTANCE;}))}},
+											{ title: 'Distance', data: function (d) { return String(Math.min.apply(Math, d.RELATIONSHIPS.map(function (o) {return o.RELATIONSHIP_DISTANCE;})))}},
 											{ title: 'Domain', data: 'DOMAIN_ID' },
 											{ title: 'Vocabulary', data: 'VOCABULARY_ID', width: '100px' }
 									]
@@ -112,7 +112,7 @@
 												{ title: 'Class', data: 'CONCEPT_CLASS_ID' },
 												{ title: 'RC', data: 'RECORD_COUNT'},
 												{ title: 'DRC', data: 'DESCENDANT_RECORD_COUNT'},
-												{ title: 'Distance', data: function (d) { return Math.max.apply(Math, d.RELATIONSHIPS.map(function (o) {return o.RELATIONSHIP_DISTANCE;}))}},
+												{ title: 'Distance', data: function (d) { return String(Math.min.apply(Math, d.RELATIONSHIPS.map(function (o) {return o.RELATIONSHIP_DISTANCE;})))}},
 												{ title: 'Domain', data: 'DOMAIN_ID' },
 												{ title: 'Vocabulary', data: 'VOCABULARY_ID', width: '100px' }
 										]
@@ -142,7 +142,7 @@
 											{ title: 'Class', data: 'CONCEPT_CLASS_ID' },
 											{ title: 'RC', data: 'RECORD_COUNT'},
 											{ title: 'DRC', data: 'DESCENDANT_RECORD_COUNT'},
-											{ title: 'Distance', data: function (d) { return Math.max.apply(Math, d.RELATIONSHIPS.map(function (o) {return o.RELATIONSHIP_DISTANCE;}))}},
+											{ title: 'Distance', data: function (d) { return String(Math.max.apply(Math, d.RELATIONSHIPS.map(function (o) {return o.RELATIONSHIP_DISTANCE;})))}},
 											{ title: 'Domain', data: 'DOMAIN_ID' },
 											{ title: 'Vocabulary', data: 'VOCABULARY_ID', width: '100px' }
 									]

--- a/js/pages/concept-sets/conceptset-manager.html
+++ b/js/pages/concept-sets/conceptset-manager.html
@@ -11,8 +11,10 @@
         <button type="button" class="btn btn-primary" data-bind="click: copy, visible: canCopy(), css: { disabled: !canCreate() }">
           <i class="fa fa-copy"></i>
         </button>
+        <!-- ko if: $component.currentConceptSet().id != null && $component.currentConceptSet().id != 0 -->
         <button type="button" class="btn btn-primary" data-bind="click: optimize, css: { disabled: !canEdit() && !canCreate() }">Optimize</button>
         <button type="button" class="btn btn-danger" data-bind="click: $component.delete, css: { disabled: !canDelete() }"><i class="fa fa-trash-o"></i></button>
+        <!-- /ko -->
       </div>
     </div>
     <div data-bind="visible: !isNameCorrect()" class="empty-name-error">

--- a/js/pages/concept-sets/conceptset-manager.html
+++ b/js/pages/concept-sets/conceptset-manager.html
@@ -12,7 +12,7 @@
           <i class="fa fa-copy"></i>
         </button>
         <!-- ko if: $component.currentConceptSet().id != null && $component.currentConceptSet().id != 0 -->
-        <button type="button" class="btn btn-primary" data-bind="click: optimize, css: { disabled: !canEdit() && !canCreate() }">Optimize</button>
+        <button type="button" class="btn btn-primary" data-bind="click: optimize, css: { disabled: !canOptimize() }">Optimize</button>
         <button type="button" class="btn btn-danger" data-bind="click: $component.delete, css: { disabled: !canDelete() }"><i class="fa fa-trash-o"></i></button>
         <!-- /ko -->
       </div>

--- a/js/pages/concept-sets/conceptset-manager.js
+++ b/js/pages/concept-sets/conceptset-manager.js
@@ -80,6 +80,15 @@ define([
 				}
 			});
 			this.canDelete = this.model.canDeleteCurrentConceptSet;
+			this.canOptimize = ko.computed(() => {
+				return (
+					this.currentConceptSet() 
+					&& this.currentConceptSet().id != 0 
+					&& sharedState.selectedConcepts().length > 1
+					&& this.canCreate()
+					&& this.canEdit()
+				);
+			}); 
 			this.optimalConceptSet = ko.observable(null);
 			this.optimizerRemovedConceptSet = ko.observable(null);
 			this.optimizerSavingNew = ko.observable(false);

--- a/js/pages/concept-sets/routes.js
+++ b/js/pages/concept-sets/routes.js
@@ -6,7 +6,6 @@ define(
         appModel.activePage(this.title);
         require(['./conceptset-manager', 'components/cohort-definition-browser', 'conceptset-list-modal'], function () {
           appModel.loadConceptSet(conceptSetId, 'conceptset-manager', 'repository', mode);
-          appModel.resolveConceptSetExpression();
         });
       });
 

--- a/js/services/Vocabulary.js
+++ b/js/services/Vocabulary.js
@@ -198,10 +198,10 @@ define(function (require, exports) {
 	}
 
 	function optimizeConceptSet(conceptSetItems, url, sourceKey) {
-		var repositoryUrl = (url || config.webAPIRoot) + 'vocabulary/' + (sourceKey || defaultSource.sourceKey) + '/optimize';
+		var vocabUrl = sourceKey === undefined ? sharedState.vocabularyUrl() : (url || config.webAPIRoot) + 'vocabulary/' + sourceKey;
 
 		var getOptimizedConceptSetPromise = $.ajax({
-			url: repositoryUrl,
+			url:  vocabUrl + 'optimize',
 			data: JSON.stringify(conceptSetItems),
 			method: 'POST',
 			contentType: 'application/json',

--- a/js/services/Vocabulary.js
+++ b/js/services/Vocabulary.js
@@ -212,10 +212,10 @@ define(function (require, exports) {
 	}
 
 	function compareConceptSet(compareTargets, url, sourceKey) {
-		var repositoryUrl = (url || config.webAPIRoot) + 'vocabulary/' + (sourceKey || defaultSource.sourceKey) + '/compare';
+		var vocabUrl = sourceKey === undefined ? sharedState.vocabularyUrl() : (url || config.webAPIRoot) + 'vocabulary/' + sourceKey;
 
 		var getComparedConceptSetPromise = $.ajax({
-			url: repositoryUrl,
+			url: vocabUrl + 'compare',
 			data: JSON.stringify(compareTargets),
 			method: 'POST',
 			contentType: 'application/json',


### PR DESCRIPTION
This PR aims to address a number of concept set/vocabulary bugs:

#282 - Concept Set Comparison Caching Definition
#568 - Multiple resolveConceptSetExpressions result in race condition
#620 - Optimizing a null conceptset causes issue
#702 - Trashing an unsaved concept set
#728 - Distance in hierarchy does not match value from concept_ancestor
#1133 - Clicking the "save new concept set from selection below" button in concept set compare tab creates odd concept set
#1228 - Import concept set in cohort definition throws error
#1229 - Optimize concept set fails

The commits in this PR are organized by the issues above. Please let me know if you have any questions or concerns with these fixes.