### PR TITLE
Fail app bootstrapping process if user info is unavailable

### DIFF
--- a/js/Application.js
+++ b/js/Application.js
@@ -52,6 +52,14 @@ define(
 					}, document.getElementsByTagName('html')[0]);
 					httpService.setUnauthorizedHandler(() => authApi.resetAuthParams());
 					httpService.setUserTokenGetter(() => authApi.getAuthorizationHeader());
+					if (config.userAuthenticationEnabled) {
+						try {
+							await authApi.loadUserInfo();
+						} catch (e) {
+							reject(e.message);
+						}
+
+					}
 					authApi.isAuthenticated.subscribe(executionService.checkExecutionEngineStatus);
 					this.router.setCurrentViewHandler(this.pageModel.handleViewChange);
 					this.router.setModelGetter(() => this.pageModel);

--- a/js/services/AuthAPI.js
+++ b/js/services/AuthAPI.js
@@ -45,23 +45,25 @@ define(function(require, exports) {
     var permissions = ko.observable();
 
     const loadUserInfo = function() {
-        return $.ajax({
+        return new Promise((resolve, reject) => $.ajax({
             url: config.api.url + 'user/me',
             method: 'GET',
             success: function (info) {
                 subject(info.login);
                 permissions(info.permissions.map(p => p.permission));
+                resolve();
             },
             error: function (err) {
-                console.log('User is not authed');
-                subject(null);
+                if (err.status === 401) {
+                    console.log('User is not authed');
+                    subject(null);
+                    resolve();
+                } else {
+                    reject('Cannot retrieve user info');
+                }
             }
-        });
+        }));
     };
-
-    if (config.userAuthenticationEnabled) {
-        loadUserInfo();
-    }
 
     var tokenExpirationDate = ko.pureComputed(function() {
         if (!token()) {


### PR DESCRIPTION
The PR fixes Atlas behavior, when it is not showing error when app is in secured mode, sources were cached and WebAPI is down