### PR TITLE
Fixed flex container and margins to display Pathways results on small display properly

### DIFF
--- a/js/pages/pathways/components/tabs/pathway-results.less
+++ b/js/pages/pathways/components/tabs/pathway-results.less
@@ -72,8 +72,10 @@
   &__report-group {
     margin-bottom: 3rem;
     display: flex;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     justify-content: center;
+    margin-left: -.75rem;
+    margin-right: -.75rem;
   }
 
   &__sunburst > div {
@@ -87,13 +89,6 @@
     flex-shrink: 0;
     margin-left: .75rem;
     margin-right: .75rem;
-
-    &:first-child {
-      margin-left: 0;
-    }
-    &:last-child {
-      margin-right: 0;
-    }
   }
 
   &__legend-panel {


### PR DESCRIPTION
fixes https://github.com/OHDSI/Atlas/issues/1219

![image](https://user-images.githubusercontent.com/10010071/51632872-552cf380-1f1e-11e9-962a-5a46c91d2d0f.png)


