### PR TITLE
Pathways - remove observable from status property

### DIFF
--- a/js/pages/pathways/components/tabs/pathway-executions.js
+++ b/js/pages/pathways/components/tabs/pathway-executions.js
@@ -82,7 +82,7 @@ define([
 					data: 'results',
 					className: this.classes('col-exec-results'),
 					render: (s, p, d) => {
-						return d.status() === this.pathwayGenerationStatusOptions.COMPLETED ? `<a data-bind="css: $component.classes('reports-link'), click: $component.goToResults.bind(null, id)">View reports</a>` : '-';
+						return d.status === this.pathwayGenerationStatusOptions.COMPLETED ? `<a data-bind="css: $component.classes('reports-link'), click: $component.goToResults.bind(null, id)">View reports</a>` : '-';
 					}
 				}
 			];


### PR DESCRIPTION
@pavgra While testing #1252, I was running into an issue when loading up executions for pathways:

![image](https://user-images.githubusercontent.com/12902366/51710261-8d076a00-1ff6-11e9-8801-2292aa04d164.png)

It is unrelated to related to changes #1252 but since I came across it, I wanted to see if you are getting anything similar? If so, let's either bring it into your branch or master.