### PR TITLE
Make source selection always reference the objects to select instead of returning keys.

### DIFF
--- a/js/components/generation/select-sources-btn.html
+++ b/js/components/generation/select-sources-btn.html
@@ -8,7 +8,7 @@
 <!-- ko if: $component.shouldSuggestSelection() -->
     <select-sources-popup params="{
 		showModal: $component.isPopupShown,
-		sources: $component.sources,
+		sources: $component.sourceOptions,
 		selectedSources: $component.selectedSources,
 		submit: $component.generate
 	}"></select-sources-popup>

--- a/js/components/generation/select-sources-btn.html
+++ b/js/components/generation/select-sources-btn.html
@@ -8,7 +8,7 @@
 <!-- ko if: $component.shouldSuggestSelection() -->
     <select-sources-popup params="{
 		showModal: $component.isPopupShown,
-		sources: $component.sourceOptions,
+		sources: $component.sources,
 		selectedSources: $component.selectedSources,
 		submit: $component.generate
 	}"></select-sources-popup>

--- a/js/components/generation/select-sources-btn.js
+++ b/js/components/generation/select-sources-btn.js
@@ -23,16 +23,11 @@ define([
 			this.label = typeof params.label === 'undefined' ? 'Generate' : params.label;
 			this.wasGenerated = typeof params.wasGenerated === 'undefined' ? false : params.wasGenerated;
 
-			this.sourceOptions = ko.computed(() => (ko.utils.unwrapObservable(params.sources) || []).map(s => ({
-				name: s.sourceName,
-				disabled: typeof s.disabled !== 'undefined' ? s.disabled : false,
-				disabledReason: s.disabledReason,
-				source: s
-			})));
+			this.sources = params.sources || ko.observableArray();
 			this.selectedSources = params.selectedSources || ko.observableArray();
 			this.callback = params.callback;
 
-			this.shouldSuggestSelection = ko.computed(() => this.sourceOptions().length > 1);
+			this.shouldSuggestSelection = ko.computed(() => this.sources().length > 1);
 			this.isPopupShown = ko.observable(false);
 		}
 

--- a/js/components/generation/select-sources-btn.js
+++ b/js/components/generation/select-sources-btn.js
@@ -23,17 +23,16 @@ define([
 			this.label = typeof params.label === 'undefined' ? 'Generate' : params.label;
 			this.wasGenerated = typeof params.wasGenerated === 'undefined' ? false : params.wasGenerated;
 
-			this.sources = ko.computed(() => params.sources().map(s => ({
+			this.sourceOptions = ko.computed(() => (ko.utils.unwrapObservable(params.sources) || []).map(s => ({
 				name: s.sourceName,
-				key: s.sourceKey,
 				disabled: typeof s.disabled !== 'undefined' ? s.disabled : false,
 				disabledReason: s.disabledReason,
-				selected: ko.observable()
+				source: s
 			})));
-			this.selectedSources = ko.observableArray((this.sources().length === 1 && !this.sources().disabled) ? [this.sources()[0].key] : []);
+			this.selectedSources = params.selectedSources || ko.observableArray();
 			this.callback = params.callback;
 
-			this.shouldSuggestSelection = ko.computed(() => this.sources().length > 1);
+			this.shouldSuggestSelection = ko.computed(() => this.sourceOptions().length > 1);
 			this.isPopupShown = ko.observable(false);
 		}
 
@@ -46,10 +45,12 @@ define([
 		}
 
 		generate() {
-			if (this.selectedSources().length === 0) {
+			const selectedSources = ko.utils.unwrapObservable(this.selectedSources);
+			
+			if (selectedSources.length === 0) {
 				alert('Pick at least one source to generate')
 			}
-			this.callback(this.selectedSources());
+			this.callback(selectedSources);
 			this.hidePopup();
 		}
 

--- a/js/components/generation/select-sources-popup.html
+++ b/js/components/generation/select-sources-popup.html
@@ -2,7 +2,7 @@
 										 title: 'Select sources',
 										 dialogExtraClasses: [$component.classes('dialog')],
 										 data: {
-										 	sources: $component.sources,
+										 	sourceOptions: $component.sourceOptions,
 										 	columns: $component.columns,
 										 	buttons: $component.buttons,
 										 	tableDom: $component.tableDom,
@@ -14,7 +14,7 @@
 										 }">
 	<faceted-datatable
 	    data-bind="css: classes('tbl')"
-        params="order: [1, 'asc'], reference: sources, columns: columns, buttons: buttons, dom: tableDom, options: { pageLength: 50 }, createdRow: onRowCreated, rowClick: toggle "
+        params="order: [1, 'asc'], reference: sourceOptions, columns: columns, buttons: buttons, dom: tableDom, options: { pageLength: 50 }, createdRow: onRowCreated, rowClick: toggle "
     ></faceted-datatable>
     <div data-bind="css: classes('footer')">
         <button type="button" data-bind="click: generate, css: classes({ element: 'gen-btn', extra: 'btn btn-sm btn-primary' }), disable: selectedSources().length <= 0">

--- a/js/components/generation/select-sources-popup.js
+++ b/js/components/generation/select-sources-popup.js
@@ -24,14 +24,13 @@ define([
 
 			this.showModal = params.showModal;
 			this.selectedSources = params.selectedSources;
-			this.sources = ko.computed(() => params.sources().map(s => ({ ...s, selected: this.selectedSources().includes(s.key) })));
+			this.sources = ko.computed(() => params.sources().map(s => ({ ...s, selected: ko.computed(() => this.selectedSources().includes(s.source)) })));
 			this.submit = params.submit;
 
 			this.tableDom = "Bfrt";
 
 			this.columns = [
 				{
-					data: 'key',
 					class: this.classes({ element: 'col', modifiers: 'selector', extra: 'text-center' }),
 					render: () => renderers.renderCheckbox('selected', false),
 					searchable: false,
@@ -47,11 +46,11 @@ define([
 
 			this.buttons = [
 				{
-					text: 'Select All', action: () => this.toggleSelected(true), className: this.classes({ element: 'select-all', extra: 'btn btn-sm btn-success' }),
+					text: 'Select All', action: () => this.toggleAll(true), className: this.classes({ element: 'select-all', extra: 'btn btn-sm btn-success' }),
 					init: this.removeClass('dt-button')
 				},
 				{
-					text: 'Deselect All', action: () => this.toggleSelected(false), className: this.classes({ element: 'deselect-all', extra: 'btn btn-sm btn-primary' }),
+					text: 'Deselect All', action: () => this.toggleAll(false), className: this.classes({ element: 'deselect-all', extra: 'btn btn-sm btn-primary' }),
 					init: this.removeClass('dt-button')
 				}
 			];
@@ -61,22 +60,17 @@ define([
 			};
 		}
 
-		isSelected(key) {
-			return this.selectedSources().includes(key);
-		}
-
-		toggle(source) {
-			if (!source.disabled) {
+		toggle(sourceOption) {
+			if (!sourceOption.disabled) {
 				const ss = this.selectedSources();
-				const key = source.key;
-				ss.includes(key) ? ss.splice( ss.indexOf(key), 1 ) : ss.push(key);
+				ss.includes(sourceOption.source) ? ss.splice( ss.indexOf(sourceOption.source), 1 ) : ss.push(sourceOption.source);
 				this.selectedSources(ss);
 			}
 		}
 
 		toggleAll(selected) {
 			if (selected) {
-				this.selectedSources(this.sources().filter(s => !s.disabled).map(s => s.key));
+				this.selectedSources(this.sources().filter(s => !s.disabled).map((o) => o.source));
 			} else {
 				this.selectedSources([]);
 			}

--- a/js/components/generation/select-sources-popup.js
+++ b/js/components/generation/select-sources-popup.js
@@ -24,7 +24,7 @@ define([
 
 			this.showModal = params.showModal;
 			this.selectedSources = params.selectedSources;
-			this.sources = ko.computed(() => params.sources().map(s => ({ ...s, selected: ko.computed(() => this.selectedSources().includes(s.source)) })));
+			this.sourceOptions = ko.computed(() => params.sources().map(s => ({ source: s, selected: ko.computed(() => this.selectedSources().includes(s)) })));
 			this.submit = params.submit;
 
 			this.tableDom = "Bfrt";
@@ -39,8 +39,8 @@ define([
 				{
 					class: this.classes({ element: 'col', modifiers: 'name' }),
 					title: 'Name',
-					data: 'name',
-					render: (d, t, r) => `<span>${d}` + (r.disabledReason ? `<span class="${this.classes('disabled-reason')}">(${r.disabledReason})</span>` : '') + '</span>',
+					data: 'source.sourceName',
+					render: (d, t, r) => `<span>${d}` + (r.source.disabledReason ? `<span class="${this.classes('disabled-reason')}">(${r.source.disabledReason})</span>` : '') + '</span>',
 				}
 			];
 
@@ -56,12 +56,12 @@ define([
 			];
 
 			this.onRowCreated = function( row, data, dataIndex ) {
-				data.disabled && row.classList.add('disabled');
+				data.source.disabled && row.classList.add('disabled');
 			};
 		}
 
 		toggle(sourceOption) {
-			if (!sourceOption.disabled) {
+			if (!sourceOption.source.disabled) {
 				const ss = this.selectedSources();
 				ss.includes(sourceOption.source) ? ss.splice( ss.indexOf(sourceOption.source), 1 ) : ss.push(sourceOption.source);
 				this.selectedSources(ss);
@@ -70,7 +70,7 @@ define([
 
 		toggleAll(selected) {
 			if (selected) {
-				this.selectedSources(this.sources().filter(s => !s.disabled).map((o) => o.source));
+				this.selectedSources(this.sourceOptions().filter(o => !o.source.disabled).map((o) => o.source));
 			} else {
 				this.selectedSources([]);
 			}

--- a/js/pages/incidence-rates/components/iranalysis/components/results.html
+++ b/js/pages/incidence-rates/components/iranalysis/components/results.html
@@ -53,7 +53,7 @@
 			<tr>
 				<td data-bind="css: $component.classes('tbl-col')" nowrap>
 					<!-- ko ifnot: $component.isInProgress($data) -->
-						<select-sources-btn params="sources: () => [source], callback: $component.runGenerations, wasGenerated: true, label: 'Rerun'"></select-sources-btn>
+						<select-sources-btn params="selectedSources: [source], callback: $component.runGenerations, wasGenerated: true, label: 'Rerun'"></select-sources-btn>
 					<!-- /ko -->
 					<!-- ko if: $component.isInProgress($data) -->
 						<a role="button" class="btn btn-sm btn-danger" data-bind="click: () => $component.cancelExecution(source.sourceKey), attr: {disabled: $component.stoppingSources()[source.sourceKey] }">

--- a/js/pages/incidence-rates/components/iranalysis/components/results.js
+++ b/js/pages/incidence-rates/components/iranalysis/components/results.js
@@ -151,8 +151,8 @@ define([
 			});
 		};
 
-		runGenerations(sourceKeys) {
-			sourceKeys.forEach(key => this.execute(key));
+		runGenerations(selectedSources) {
+			selectedSources.forEach(source => this.execute(source.sourceKey));
 		}
 
 		closeReport() {


### PR DESCRIPTION
When working through the changes for #1292, it was difficult to follow how the set of source choices was being transformed between the IR UI -> generate button -> select-source-popup -> IR execution callback.  In the process of several transforms, the starting point of a set of sources gets resolved to a set of keys.  While tracing through it, I was imaging some questions that might be reaised by someone who is not familar with the code:

How does the consumer know that the set of sources I pass in comes back as an array of strings that represent keys?
If i want to reuse some of this, or generalize it, does it require that an object being chosen have a 'key' property?

To simplify things, this PR changes it so that when you pass the set of sources as your 'set of options/choices', the call back will return the very same objects that you sent in, but only those that were selected by the user.

This has a nice benefit of if you want to make the button execute on a default source (without prompting the user to choose) you can just specify the 'selectedSources' as an array of a single source (you don't even need to pass in a list of sourceOptions) and clicking the button will execute directly on that source.  

In addition, this PR fixes the broken Select All and Deselect All behavior.
