### PR TITLE
Added Promise.done polyfill

### DIFF
--- a/build/polyfill.js
+++ b/build/polyfill.js
@@ -1,1 +1,12 @@
 define(['../node_modules/@babel/polyfill/dist/polyfill'], () => {});
+
+if (typeof Promise.prototype.done !== 'function') {
+  Promise.prototype.done = function (onFulfilled, onRejected) {
+    const self = arguments.length ? this.then.apply(this, arguments) : this;
+    self.then(null, function (err) {
+      setTimeout(function () {
+        throw err
+      }, 0)
+    })
+  }
+}


### PR DESCRIPTION
fixes https://github.com/OHDSI/Atlas/issues/1418

In non-bundled mode `less.js` adds polyfill for non-standardized `Promise.done`:
![image](https://user-images.githubusercontent.com/10010071/53837583-de453a80-3f60-11e9-813f-00924113a1de.png)

During bundling this thing seems to be cut off by requirejs optimizer. Even though the `Promise.done` is not a standard thing and as for me should be avoided going further, right before the release of 2.7.0 I'm not treating migration of `done` -> `then` as a good idea. Therefore, I've brought that exact piece of code from `less.js` into `polyfill.js` which is imported by bundler. 