### PR TITLE
Prevents concept set duplication 

### DIFF
--- a/js/components/conceptsetmodal/conceptSetSaveModal.js
+++ b/js/components/conceptsetmodal/conceptSetSaveModal.js
@@ -29,6 +29,12 @@ define(['knockout', 'appConfig', 'services/AuthAPI', 'services/ConceptSet', 'tex
             self.isNameUnique(false);
           });
       });
+
+      self.show.subscribe((show) => {
+        if (show) {
+          self.conceptSetName.valueHasMutated();
+        }
+      });
     }
 
     var component = {


### PR DESCRIPTION
Fixes #1425. The new code now checks to see if the concept set modal is shown and when that happens, it calls `self.conceptSetName.valueHasMutated()` which then triggers the checks to make sure the concept name is unique.