### PR TITLE
Fix concept link display

### DIFF
--- a/js/components/conceptpicker/conceptpicker.less
+++ b/js/components/conceptpicker/conceptpicker.less
@@ -1,7 +1,3 @@
-table.dataTable {
-	font-size: .9em;
-}
-
 .search-block {
     display: flex;
     align-items: center;

--- a/js/components/conceptsetbuilder/components/IncludedConcepts.js
+++ b/js/components/conceptsetbuilder/components/IncludedConcepts.js
@@ -3,12 +3,14 @@ define([
 	'knockout',
 	'text!./IncludedConcepts.html',
 	'services/VocabularyProvider',
+	'utils/CommonUtils',
 	'faceted-datatable'
 ], function (
 		$,
 		ko,
 		template,
-		VocabularyAPI) {
+		VocabularyAPI,
+		commonUtils) {
 
 	function IncludedConcepts(params) {
 
@@ -107,10 +109,7 @@ define([
 			{
 				title: 'Name',
 				data: 'CONCEPT_NAME',
-				render: function (s, p, d) {
-					var valid = d.INVALID_REASON_CAPTION == 'Invalid' ? 'invalid' : '';
-					return '<span class="' + valid + '">' + d.CONCEPT_NAME + '</span>';
-				}
+				render: commonUtils.renderLink,
 			},
 			{
 				title: 'Class',

--- a/js/components/conceptsetbuilder/components/MappedConcepts.js
+++ b/js/components/conceptsetbuilder/components/MappedConcepts.js
@@ -3,12 +3,15 @@ define([
 	'knockout',
 	'text!./MappedConcepts.html',
 	'services/VocabularyProvider',
+	'utils/CommonUtils',
 	'faceted-datatable'
 ], function (
 		$,
 		ko,
 		template,
-		VocabularyAPI) {
+		VocabularyAPI,
+		commonUtils,
+		) {
 	
 	function MappedConcepts(params) {
 		var self = this;
@@ -106,10 +109,7 @@ define([
 			{
 				title: 'Name',
 				data: 'CONCEPT_NAME',
-				render: function (s, p, d) {
-					var valid = d.INVALID_REASON_CAPTION == 'Invalid' ? 'invalid' : '';
-					return '<span class="' + valid + '">' + d.CONCEPT_NAME + '</span>';
-				}
+				render: commonUtils.renderLink,
 			},
 			{
 				title: 'Class',

--- a/js/pages/cohort-definitions/cohort-definition-manager.js
+++ b/js/pages/cohort-definitions/cohort-definition-manager.js
@@ -295,10 +295,7 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 			{
 				title: 'Name',
 				data: 'CONCEPT_NAME',
-					render: (s, p, d) => {
-					var valid = d.INVALID_REASON_CAPTION == 'Invalid' ? 'invalid' : '';
-					return '<a class="' + valid + '" href=\"#/concept/' + d.CONCEPT_ID + '\">' + d.CONCEPT_NAME + '</a>';
-				}
+				render: commonUtils.renderLink,
 			},
 			{
 				title: 'Class',

--- a/js/pages/concept-sets/components/tabs/conceptset-compare.js
+++ b/js/pages/concept-sets/components/tabs/conceptset-compare.js
@@ -129,7 +129,6 @@ define([
               INVALID_REASON_CAPTION: d.invalidReason,
               STANDARD_CONCEPT: d.standardConcept,
             };
-            console.log(concept);
             return commonUtils.renderLink(s,p,concept)
           }
         },

--- a/js/pages/concept-sets/components/tabs/conceptset-compare.js
+++ b/js/pages/concept-sets/components/tabs/conceptset-compare.js
@@ -122,10 +122,16 @@ define([
           data: d => d.conceptCode,
         },
         {
-          data: d => {
-            var valid = true; //d.INVALID_REASON_CAPTION == 'Invalid' ? 'invalid' : '';
-            return '<a class=' + valid + ' href=\'#/concept/' + d.conceptId + '\'>' + d.conceptName + '</a>';
-          },
+          render: (s,p,d) => {
+            const concept = {
+              CONCEPT_ID: d.conceptId,
+              CONCEPT_NAME: d.conceptName,
+              INVALID_REASON_CAPTION: d.invalidReason,
+              STANDARD_CONCEPT: d.standardConcept,
+            };
+            console.log(concept);
+            return commonUtils.renderLink(s,p,concept)
+          }
         },
         {
           data: d => d.conceptClassId,

--- a/js/pages/concept-sets/components/tabs/included-conceptsets.js
+++ b/js/pages/concept-sets/components/tabs/included-conceptsets.js
@@ -45,10 +45,7 @@ define([
         data: 'CONCEPT_CODE'
       }, {
         data: 'CONCEPT_NAME',
-        render: function (s, p, d) {
-          var valid = d.INVALID_REASON_CAPTION == 'Invalid' ? 'invalid' : '';
-          return '<a class="' + valid + '" href=\"#/concept/' + d.CONCEPT_ID + '\">' + d.CONCEPT_NAME + '</a>';
-        }
+        render: commonUtils.renderLink,
       }, {
         data: 'CONCEPT_CLASS_ID'
       }, {

--- a/js/pages/concept-sets/concept-manager.js
+++ b/js/pages/concept-sets/concept-manager.js
@@ -127,10 +127,7 @@ define([
 			}, {
 				title: 'Name',
 				data: 'CONCEPT_NAME',
-				render: function (s, p, d) {
-					var valid = d.INVALID_REASON_CAPTION == 'Invalid' ? 'invalid' : '';
-					return '<a class="' + valid + '" href=\"#/concept/' + d.CONCEPT_ID + '\">' + d.CONCEPT_NAME + '</a>';
-				}
+				render: commonUtils.renderLink,
 			}, {
 				title: 'Class',
 				data: 'CONCEPT_CLASS_ID'

--- a/js/pages/vocabulary/components/search.js
+++ b/js/pages/vocabulary/components/search.js
@@ -119,10 +119,7 @@ define([
 			}, {
 				title: 'Name',
 				data: 'CONCEPT_NAME',
-				render: function (s, p, d) {
-					var valid = d.INVALID_REASON_CAPTION == 'Invalid' ? 'invalid' : '';
-					return '<a class="' + valid + '" href=\"#/concept/' + d.CONCEPT_ID + '\">' + d.CONCEPT_NAME + '</a>';
-				}
+				render: commonUtils.renderLink,
 			}, {
 				title: 'Class',
 				data: 'CONCEPT_CLASS_ID'

--- a/js/styles/atlas.css
+++ b/js/styles/atlas.css
@@ -496,6 +496,14 @@ span.classification {
   padding: 5px;
 }
 
+a.classification {
+  color: #a335ee;
+}
+
+a.non-standard {
+  color: #a71a19;
+}
+
 td.invalid {
   background-color: #a71a19;
   color: #fff;

--- a/js/utils/CommonUtils.js
+++ b/js/utils/CommonUtils.js
@@ -60,7 +60,7 @@ define([
 
 	function getLinkClass(data) {
 		var switchContext;
-		if (data.STANDARD_CONCEPT == undefined) {
+		if (data.STANDARD_CONCEPT === undefined) {
 			switchContext = data.concept.STANDARD_CONCEPT;
 		} else {
 			switchContext = data.STANDARD_CONCEPT;

--- a/js/utils/CommonUtils.js
+++ b/js/utils/CommonUtils.js
@@ -58,7 +58,7 @@ define([
 		return false;
 	}
 
-	function getLinkClass(data) {
+	function getConceptLinkClass(data) {
 		var switchContext;
 		if (data.STANDARD_CONCEPT === undefined) {
 			switchContext = data.concept.STANDARD_CONCEPT;
@@ -78,7 +78,7 @@ define([
 
 	function contextSensitiveLinkColor(row, data) {
 		$('a', row)
-			.addClass(getLinkClass(data));
+			.addClass(getConceptLinkClass(data));
 	}
 
 	function hasCDM(source) {
@@ -104,12 +104,12 @@ define([
 
 	function renderLink(s, p, d) {
 		var valid = d.INVALID_REASON_CAPTION == 'Invalid' ? 'invalid' : '';
-		var linkClass = getLinkClass(d);
+		var linkClass = getConceptLinkClass(d);
 		return '<a class="' + valid + ' ' + linkClass + '" href=\"#/concept/' + d.CONCEPT_ID + '\">' + d.CONCEPT_NAME + '</a>';
 	}
 
 	function renderBoundLink(s, p, d) {
-		return '<a href=\"#/concept/' + d.concept.CONCEPT_ID + '\">' + d.concept.CONCEPT_NAME + '</a>';
+		return renderLink(s, p, d.concept);
 	}
 
 	const renderConceptSelector = function (s, p, d) {

--- a/js/utils/CommonUtils.js
+++ b/js/utils/CommonUtils.js
@@ -58,7 +58,7 @@ define([
 		return false;
 	}
 
-	function contextSensitiveLinkColor(row, data) {
+	function getLinkClass(data) {
 		var switchContext;
 		if (data.STANDARD_CONCEPT == undefined) {
 			switchContext = data.concept.STANDARD_CONCEPT;
@@ -67,14 +67,18 @@ define([
 		}
 		switch (switchContext) {
 			case 'N':
-				$('a', row)
-					.css('color', '#a71a19');
-				break;
+				return "non-standard";
 			case 'C':
-				$('a', row)
-					.css('color', '#a335ee');
-				break;
+				return "classification";
+			case 'S':
+				return 'standard';
 		}
+
+	}
+
+	function contextSensitiveLinkColor(row, data) {
+		$('a', row)
+			.addClass(getLinkClass(data));
 	}
 
 	function hasCDM(source) {
@@ -100,7 +104,8 @@ define([
 
 	function renderLink(s, p, d) {
 		var valid = d.INVALID_REASON_CAPTION == 'Invalid' ? 'invalid' : '';
-		return '<a class="' + valid + '" href=\"#/concept/' + d.CONCEPT_ID + '\">' + d.CONCEPT_NAME + '</a>';
+		var linkClass = getLinkClass(d);
+		return '<a class="' + valid + ' ' + linkClass + '" href=\"#/concept/' + d.CONCEPT_ID + '\">' + d.CONCEPT_NAME + '</a>';
 	}
 
 	function renderBoundLink(s, p, d) {


### PR DESCRIPTION
Updates the commonUtils to share a common way to determine the `standard_concept` designation of a concept and to return a css class defined in atlas.css. 

Fixes #1527 