### PR TITLE
Prevent execution of executing CC with zero cohorts(#1363)

### DIFF
--- a/js/pages/characterizations/components/characterizations/characterization-view-edit/characterization-executions.html
+++ b/js/pages/characterizations/components/characterizations/characterization-view-edit/characterization-executions.html
@@ -49,7 +49,7 @@
             <ul data-bind="css: classes({ element: 'action-list' })">
                 <li data-bind="
                     css: classes({ element: 'action' }),
-                    tooltip: !$component.isExecutionPermitted(sourceKey) ? 'Not enough permissions to generate or changes not saved' : null,
+                    tooltip: !$component.isExecutionPermitted(sourceKey) ? 'Not enough permissions to generate, changes not saved or no cohorts found' : null,
                 ">
                     <!-- ko if: $component.ccGenerationStatusOptions.COMPLETED === status() -->
                     <button data-bind="

--- a/js/pages/characterizations/components/characterizations/characterization-view-edit/characterization-executions.js
+++ b/js/pages/characterizations/components/characterizations/characterization-view-edit/characterization-executions.js
@@ -61,6 +61,8 @@ define([
 			this.exitMessage = ko.observable();
 			this.pollId = null;
 
+			this.design = params.design;
+
 			this.execColumns = [{
 					title: 'Date',
 					className: this.classes('col-exec-date'),
@@ -132,7 +134,8 @@ define([
 		}
 
 		isExecutionPermitted(sourceKey) {
-			return PermissionService.isPermittedGenerateCC(this.characterizationId(), sourceKey) && !this.designDirtyFlag().isDirty();
+			return PermissionService.isPermittedGenerateCC(this.characterizationId(), sourceKey) && !this.designDirtyFlag().isDirty() &&
+				this.design().cohorts().length;
 		}
 
 		isResultsViewPermitted(sourceKey) {


### PR DESCRIPTION
fixes #1363 

button becomes disabled when no cohorts found
hint was changed