### PR TITLE
Datatables performance/clean-up improvements

### DIFF
--- a/js/Model.js
+++ b/js/Model.js
@@ -423,7 +423,7 @@ define(
 
 			renderCheckbox(field) {
 				if (this.canEditCurrentConceptSet()) {
-					return '<span data-bind="click: function(d) { d.' + field + '(!d.' + field + '()); $root.resolveConceptSetExpression(); } ,css: { selected: ' + field + '} " class="fa fa-check"></span>';
+					return '<span data-bind="click: function(d) { d.' + field + '(!d.' + field + '()) } ,css: { selected: ' + field + '} " class="fa fa-check"></span>';
 				} else {
 					return '<span data-bind="css: { selected: ' + field + '} " class="fa fa-check readonly"></span>';
 				}

--- a/js/components/cohort-definition-browser.js
+++ b/js/components/cohort-definition-browser.js
@@ -92,8 +92,8 @@ define([
 			this.rowClick = this.rowClick.bind(this);
 		}
 		
-		renderCohortDefinitionLink (s, p, d) {
-			return '<span class="linkish">' + d.name + '</span>';
+		renderCohortDefinitionLink (data,type,row) {
+			return (type == "display")	? `<span class="linkish">${row.name}</span>` : row.name;
 		}
 
 		rowClick(data) {

--- a/js/extensions/bindings/profileChart.js
+++ b/js/extensions/bindings/profileChart.js
@@ -46,7 +46,7 @@ define([
 
 	var htmlTipText = d => {
 		var tipText = '<p>Event: ' + d.conceptName + '</p><p>Start Day: ' + d.startDay + '</p>';
-		if (authApi.isPermittedViewProfileDates() && d.startDate != null) {
+		if (canViewProfileDates() && d.startDate != null) {
 			tipText += '<p>Start Date: ' + momentApi.formatDate(new Date(d.startDate)) + '</p>'
 		}
 		return tipText;

--- a/js/pages/cohort-definitions/cohort-definition-manager.html
+++ b/js/pages/cohort-definitions/cohort-definition-manager.html
@@ -79,7 +79,7 @@
 													stripeClasses : [ 'repositoryConceptSetItem' ],
 													columns: [
 															{ data: 'id', title: 'Id', width: '25px'},
-															{ data: 'name', title: 'Title', width: '100%' },
+															$component.getDataboundColumn('name', 'Title', '100%')
 													],
 													language: {
 															search: 'Filter Cohort Concept Sets:'

--- a/js/pages/cohort-definitions/cohort-definition-manager.js
+++ b/js/pages/cohort-definitions/cohort-definition-manager.js
@@ -87,7 +87,7 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 		var textB = b.name().toUpperCase();
 		return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;
 	}
-
+	
 	class CohortDefinitionManager extends AutoBind(Clipboard(Page)) {
 		constructor(params) {
 			super(params);
@@ -1252,6 +1252,18 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 			setExpressionJson(value) {
 				this.modifiedJSON = value;
 			}
+				
+			getDataboundColumn(field, title, width) {
+				return { 
+					data: field,
+					title: title, 
+					width: width, 
+					render: function (data,type,row) {
+						return (type == "display")	? `<span data-bind='text: ${field}'></span>` 
+																				: ko.utils.unwrapObservable(data)
+					} 
+				}
+			}				
 	}
 
 	return commonUtils.build('cohort-definition-manager', CohortDefinitionManager, view);

--- a/js/pages/cohort-definitions/components/checks/conceptset-warnings.html
+++ b/js/pages/cohort-definitions/components/checks/conceptset-warnings.html
@@ -3,8 +3,8 @@
 </div>
 <div data-bind="eventListener:[{event:'click', selector: '.btn-fix', callback: fixRedundantConceptSet}]">
     <div class="conceptset-warnings">
-        <faceted-datatable params="{columns: $component.warningsColumns, options: $component.warningsOptions,reference: $component.warnings, order: [],
-           drawCallback: $component.drawCallback, stateSaveCallback: $component.stateSaveCallback, stateLoadCallback: $component.stateLoadCallback}"></faceted-datatable>
-    </div>
+<faceted-datatable params="{columns: $component.warningsColumns, options: $component.warningsOptions,reference: $component.warnings, order: [],
+           drawCallback: $component.drawCallback}"></faceted-datatable>
+		</div>
 </div>
 <loading data-bind="visible: loading" params="status: 'Running Diagnostics'"></loading>

--- a/js/pages/concept-sets/components/tabs/conceptset-expression.html
+++ b/js/pages/concept-sets/components/tabs/conceptset-expression.html
@@ -1,5 +1,6 @@
 <div class="paddedWrapper">
   <table class="conceptSetTable stripe compact hover" cellspacing="0" width="100%" data-bind="dataTable:{
+        xssSafe: true,																																															
         data: selectedConcepts(),
         options: {
           dom: 'Clfiprt',


### PR DESCRIPTION
This is ready for review.

Following changes:
- Allow table to be marked 'xssSafe' to prevent unnecessary string parsing and formatting.
- Modifications to datatabinding to not trigger dependency tracking during redraws.
- Added cleanup (via DataTable.destroy()) when binding's element is disposed.
- Had to disable saveState/loadState callbacks from Warnings compnent: this led to a conflict.
- Found some cases where data-tables `render` options were returning the same formatted value for all types of render (type, sort, display, filter) which led to strange sorting results with hyperlinks.  This could also be applied to fix sorting on date columns that are currently using moment-parse-date routines that are extremely expensive. (However, not addressed in this PR).


Partially addresses #1581.
Fixes #1636.


