### PR TITLE
Fixed loading permissions for IAP

### DIFF
--- a/js/components/welcome.js
+++ b/js/components/welcome.js
@@ -20,6 +20,7 @@ define([
         const bemHelper = new BemHelper(componentName);
 		this.classes = bemHelper.run.bind(bemHelper);
         self.token = authApi.token;
+        self.loadUserInfo = authApi.loadUserInfo;
         self.setAuthParams = authApi.setAuthParams;
         self.resetAuthParams = authApi.resetAuthParams;
         self.serviceUrl = appConfig.webAPIRoot;
@@ -61,11 +62,12 @@ define([
         };
 
         self.onLoginSuccessful = function(data, textStatus, jqXHR) {
-            self.setAuthParams(jqXHR.getResponseHeader(authApi.TOKEN_HEADER)).then(() => {
+            self.setAuthParams(jqXHR.getResponseHeader(authApi.TOKEN_HEADER), data.permissions);
+            self.loadUserInfo().then(() => {
                 self.errorMsg(null);
                 self.isBadCredentials(null);
                 self.isInProgress(false);
-            });
+            })
         };
 
         self.onLoginFailed = function(jqXHR, defaultMessage) {

--- a/js/pages/Route.js
+++ b/js/pages/Route.js
@@ -9,11 +9,14 @@ define([
 ) {
 	class Route {
 		checkPermission() {
-			if (appConfig.userAuthenticationEnabled && authApi.token() != null && authApi.tokenExpirationDate() > new Date()) {
+			if (
+				appConfig.userAuthenticationEnabled &&
+				((authApi.token() != null && authApi.tokenExpirationDate() > new Date()) ||
+					authApi.authProvider() === authApi.AUTH_PROVIDERS.IAP)
+			) {
 				return authApi.refreshToken();
-			} else {
-				return new Promise(resolve => resolve());
-			}      
+			}
+			return Promise.resolve();
 		}
 
 		constructor(handler) {

--- a/js/services/AuthAPI.js
+++ b/js/services/AuthAPI.js
@@ -237,7 +237,7 @@ define(function(require, exports) {
         if (!isPromisePending(refreshTokenPromise)) {
           refreshTokenPromise = httpService.doGet(getServiceUrl() + "user/refresh");
           refreshTokenPromise.then(({ data, headers }) => {
-            setAuthParams(headers.get(TOKEN_HEADER));
+            setAuthParams(headers.get(TOKEN_HEADER), data.permissions);
           });
           refreshTokenPromise.catch(() => {
             resetAuthParams();
@@ -446,11 +446,12 @@ define(function(require, exports) {
 
     const hasSourceAccess = function (sourceKey) {
         return isPermitted(`source:${sourceKey}:access`) || /* For 2.5.* and below */ isPermitted(`cohortdefinition:*:generate:${sourceKey}:get`);
-	}
+    }
 
-	var setAuthParams = function (tokenHeader) {
-        token(tokenHeader);
-        return loadUserInfo();
+
+	const setAuthParams = (tokenHeader, permissionsStr = '') => {
+        !!tokenHeader && token(tokenHeader);
+        !!permissionsStr && permissions(permissionsStr.split('|'));
     };
 
     var resetAuthParams = function () {


### PR DESCRIPTION
Fixes #1612 #1599 

- Setting permissions from data returned on refresh token call
- Remove loading of user info on change of route.