### PR TITLE
Concept set import fixes

### DIFF
--- a/js/Model.js
+++ b/js/Model.js
@@ -459,13 +459,15 @@ define(
 			}
 
 			setConceptSet(conceptset, expressionItems) {
+				var conceptSetItemsToAdd = [];
 				expressionItems.forEach((conceptSet) => {
 					const conceptSetItem = conceptSetService.enchanceConceptSet(conceptSet);
 					
 					sharedState.selectedConceptsIndex[conceptSetItem.concept.CONCEPT_ID] = 1;
-					sharedState.selectedConcepts.push(conceptSetItem);
+					conceptSetItemsToAdd.push(conceptSetItem);
 				});
 
+				sharedState.selectedConcepts(conceptSetItemsToAdd);
 				this.currentConceptSet({
 					name: ko.observable(conceptset.name),
 					id: conceptset.id

--- a/js/pages/cohort-definitions/cohort-definition-manager.js
+++ b/js/pages/cohort-definitions/cohort-definition-manager.js
@@ -974,10 +974,14 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 			};
 
 			appendConcepts(response) {
+				var conceptSetItemsToAdd = sharedState.selectedConcepts();
 				response.data.forEach((item) => {
-					sharedState.selectedConceptsIndex[item.CONCEPT_ID] = 1;
-						sharedState.selectedConcepts.push(this.model.createConceptSetItem(item));
+					if (sharedState.selectedConceptsIndex[item.CONCEPT_ID] != 1) {
+						sharedState.selectedConceptsIndex[item.CONCEPT_ID] = 1;
+						conceptSetItemsToAdd.push(commonUtils.createConceptSetItem(item));
+					}
 				});
+				sharedState.selectedConcepts(conceptSetItemsToAdd);
 				if (this.model.currentCohortDefinition() && this.model.currentConceptSetSource() === "cohort") {
 					var conceptSet = this.model.currentCohortDefinition()
 						.expression()

--- a/js/pages/vocabulary/components/import.js
+++ b/js/pages/vocabulary/components/import.js
@@ -33,7 +33,8 @@ define([
 		}
 
 		showConceptSet() {
-			document.location = '#/conceptset/0/details';	
+			const conceptSetId = this.model.currentConceptSet() ? this.model.currentConceptSet().id : 0;
+			document.location = `#/conceptset/${conceptSetId}/details`;	
 		}
 
 		importConceptSetExpression() {
@@ -120,13 +121,14 @@ define([
 						this.model.currentConceptSetSource('repository');
 					}
 
+					var conceptSetItemsToAdd = sharedState.selectedConcepts();
 					for (var i = 0; i < conceptSetItems.length; i++) {
 						if (sharedState.selectedConceptsIndex[conceptSetItems[i].CONCEPT_ID] != 1) {
 							sharedState.selectedConceptsIndex[conceptSetItems[i].CONCEPT_ID] = 1;
-							var conceptSetItem = this.model.createConceptSetItem(conceptSetItems[i]);
-							sharedState.selectedConcepts.push(conceptSetItem);
+							conceptSetItemsToAdd.push(commonUtils.createConceptSetItem(conceptSetItems[i]));
 						}
 					}
+					sharedState.selectedConcepts(conceptSetItemsToAdd);
 					resolve();
 				} catch(er) {
 					reject(er);


### PR DESCRIPTION
Per #1532, this PR updates the way in which we import concept identifiers so that we're not pushing each individual item into the `sharedState.selectedConcepts` observableArray. Instead, we add the items to a traditional array and once complete, set `sharedState.selectedConcepts` to take that array as its value.

This PR also addresses #1525 so that you can append concept identifiers to an open repository concept set without having to do additional work. This changes makes the repository and cohort concept set experience identical - you can append concepts through the import functionality. 
