### PR TITLE
Select all concepts fix

### DIFF
--- a/js/Application.js
+++ b/js/Application.js
@@ -122,8 +122,9 @@ define(
 							}
 						}
 						sharedState.selectedConcepts(selectedConcepts);
-						ko.contextFor(this)
-							.$component.reference.valueHasMutated();
+						for (var i = 0; i < table.rows()[0].length; i++) {
+							table.cell(i,0).data('<i class="fa fa-shopping-cart"></i>');
+						}
 					});
 
 				// handling concept set selections


### PR DESCRIPTION
Per #1526, when using the "select all" on a faceted data table, the concepts are properly selected but the table's state is reset wiping out any user-defined facet filters, options, etc. To accomplish this, I've removed the call to `ko.contextFor(this).$component.reference.valueHasMutated()` since this call causes the entire data table to be re-drawn which is inefficient. 

Instead, I've reused the `table` variable that is declared earlier in the function to obtain the concepts that exist in the data table with all of the filters/options applied. The loop below:

```
for (var i = 0; i < table.rows()[0].length; i++) {
	table.cell(i,0).data('<i class="fa fa-shopping-cart"></i>');
}
```

What this is doing is obtaining the length of the filtered data: `table.rows()[0].length` and then applies the "selected shopping cart" to each row in the table: `table.cell(i,0).data('<i class="fa fa-shopping-cart"></i>');`