### PR TITLE
Vocabulary search - handle special characters

### DIFF
--- a/js/pages/vocabulary/components/search.js
+++ b/js/pages/vocabulary/components/search.js
@@ -190,9 +190,13 @@ define([
 				this.getVocabularies();
 			}
 		}
+		
+		encodeSearchString(searchTerm) {
+			return encodeURIComponent(searchTerm.replace("/", " "));
+		}
 
 		searchClick() {
-			const redirectUrl = '#/search/' + encodeURIComponent(this.currentSearch().replace("/", " "));
+			const redirectUrl = '#/search/' + this.encodeSearchString(this.currentSearch());
 			if (this.selected.vocabularies.size > 0 || this.selected.domains.size > 0 || document.location.hash === redirectUrl) {
 				this.executeSearch();
 			} else if (this.currentSearch().length > 2) {
@@ -264,7 +268,7 @@ define([
 				return;
 			}
 
-			const query = this.currentSearch() === undefined ? '' : this.currentSearch();
+			const query = this.currentSearch() === undefined ? '' : this.encodeSearchString(this.currentSearch());
 			this.loading(true);
 			this.data([]);
 

--- a/js/pages/vocabulary/components/search.js
+++ b/js/pages/vocabulary/components/search.js
@@ -190,9 +190,13 @@ define([
 				this.getVocabularies();
 			}
 		}
+
+		replaceSpecialCharacters(str) {
+			return str.replace("/", " ");
+		}
 		
 		encodeSearchString(searchTerm) {
-			return encodeURIComponent(searchTerm.replace("/", " "));
+			return encodeURIComponent(this.replaceSpecialCharacters(searchTerm));
 		}
 
 		searchClick() {
@@ -268,7 +272,11 @@ define([
 				return;
 			}
 
-			const query = this.currentSearch() === undefined ? '' : this.encodeSearchString(this.currentSearch());
+			let query = ''; 
+			if (this.currentSearch() !== undefined) {
+				query = this.encodeSearchString(this.currentSearch());	
+				this.currentSearch(this.replaceSpecialCharacters(this.currentSearch()));
+			}
 			this.loading(true);
 			this.data([]);
 

--- a/js/pages/vocabulary/components/search.js
+++ b/js/pages/vocabulary/components/search.js
@@ -192,7 +192,7 @@ define([
 		}
 
 		searchClick() {
-			const redirectUrl = '#/search/' + escape(this.currentSearch());
+			const redirectUrl = '#/search/' + encodeURIComponent(this.currentSearch().replace("/", " "));
 			if (this.selected.vocabularies.size > 0 || this.selected.domains.size > 0 || document.location.hash === redirectUrl) {
 				this.executeSearch();
 			} else if (this.currentSearch().length > 2) {


### PR DESCRIPTION
Fixes #250 through proper encoding and a work-around for the "/". The way search currently work is by redirecting to a new URL:

`atlas/#/search/<search term>`

If your `<search term>` contains a "/" it messes up the route handling since it can't determine if the "/" is part of the URL or instead is part of the search term. I've added a work-around that eliminates the "/" from the search itself and replaces it with a space. This is a hack for sure but is a quick fix and takes advantage of the current search which will insert a wildcard for spaces. 