### PR TITLE
Update plp/ple settings display - fixes #1710

### DIFF
--- a/js/pages/estimation/components/cca-specification-view-edit.js
+++ b/js/pages/estimation/components/cca-specification-view-edit.js
@@ -32,6 +32,7 @@ define([
 			this.editorComponentParams = ko.observable({});
 			this.editorDescription = ko.observable();
 			this.editorHeading = ko.observable();
+			this.editorArray = ko.observableArray();
 			this.estimationAnalysis = params.estimationAnalysis;
 			this.options = constants.options;
 			this.loading = params.loading;
@@ -81,6 +82,7 @@ define([
 		}
 
 		editAnalysis(analysis) {
+			this.editorArray = this.cohortMethodAnalysisList;
 			this.editorHeading('Analysis Settings');
 			this.editorDescription('Add or update the analysis settings');
 			this.editorComponentName('cohort-method-analysis-editor');
@@ -108,6 +110,7 @@ define([
 		}
 
 		editComparison(comparison) {
+			this.editorArray = this.comparisons;
 			this.editorHeading('Comparison');
 			this.editorDescription('Add or update the target, comparator, outcome(s) cohorts and negative control outcomes');
 			this.editorComponentName('comparison-editor');
@@ -136,6 +139,7 @@ define([
 		}
 
 		closeEditor() {
+			this.editorArray.valueHasMutated();
 			this.managerMode('summary');
 		}
 	}

--- a/js/pages/prediction/components/prediction-specification-view-edit.js
+++ b/js/pages/prediction/components/prediction-specification-view-edit.js
@@ -33,6 +33,7 @@ define([
 			this.editorComponentParams = ko.observable({});
 			this.editorDescription = ko.observable();
 			this.editorHeading = ko.observable();
+			this.editorArray = ko.observableArray();
 			this.options = constants.options;
 			this.managerMode = ko.observable('summary');
 			this.patientLevelPredictionAnalysis = params.patientLevelPredictionAnalysis;
@@ -146,6 +147,7 @@ define([
 		}
 
 		editCovariateSettings(settings) {
+			this.editorArray = this.covariateSettings;
 			this.editorHeading('Covariate Settings');
 			this.editorDescription('Add or update the covariate settings');
 			this.editorComponentName('prediction-covar-settings-editor');
@@ -167,6 +169,7 @@ define([
 			if (editor === undefined) {
 				editor = option.editor;
 			}
+			this.editorArray = this.modelSettings;
 			this.editorHeading(option.name + ' Model Settings');
 			this.editorDescription('Use the options below to edit the model settings');
 			this.editorComponentName('model-settings-editor');
@@ -187,6 +190,7 @@ define([
 		}
 
 		editPopulationSettings(settings) {
+			this.editorArray = this.populationSettings;
 			this.editorHeading('Population Settings');
 			this.editorDescription('Add or update the population settings');
 			this.editorComponentName('population-settings-editor');
@@ -198,6 +202,7 @@ define([
 		}		
 
 		closeEditor() {
+			this.editorArray.valueHasMutated();
 			this.managerMode('summary');
 		}
 


### PR DESCRIPTION
For Estimation & Prediction, call the `valueHasMutated` on the referenced observableArray to force the summary table to reload once the user is done editing the values.