### PR TITLE
Treemap component disposal - Fixes #1715

### DIFF
--- a/js/pages/data-sources/classes/Treemap.js
+++ b/js/pages/data-sources/classes/Treemap.js
@@ -35,10 +35,6 @@ define([
 			this.byOperator = false;
 			this.byQualifier = false;
 
-			this.dispose = function () {
-				this.currentConceptSubscription.dispose();
-			}
-
 			this.chartFormats = {
 				treemap: {
 					useTip: true,
@@ -126,6 +122,11 @@ define([
 
 		selectTab(tab) {
 
+		}
+
+		dispose() {
+			this.currentConceptSubscription.dispose();
+			super.dispose();
 		}
 
 		parseData({

--- a/js/pages/data-sources/data-sources.js
+++ b/js/pages/data-sources/data-sources.js
@@ -161,7 +161,7 @@ define([
 				this.currentReport(this.reports.find(r => r.path == changedParams.reportName));
 				this.selectedReport(this.reports.find(r => r.path == changedParams.reportName));
 			} else {
-				if (changedParams.sourceKey) {
+				if (changedParams.sourceKey && this.currentSource() && changedParams.sourceKey !== this.currentSource().sourceKey) {
 					this.currentSource(this.sources().find(s => s.sourceKey == newParams.sourceKey));
 				}
 				if (changedParams.reportName) {


### PR DESCRIPTION
Moved `dispose()` out of constructor and added call to parent class `dispose()` to ensure proper subscription cleanup that was making extraneous calls to WebAPI after viewing different reports and then switching sources.

Added an additional condition to `js/pages/data-sources/data-sources.js` to prevent multiple calls to the `updateLocation()` which was also contributing to extra WebAPI traffic.