### PR TITLE
Get record counts for non-standard concepts

### DIFF
--- a/js/services/Vocabulary.js
+++ b/js/services/Vocabulary.js
@@ -48,13 +48,10 @@ define(function (require, exports) {
 		var searchResultIdentifiers = [];
 		var resultsIndex = [];
 		for (c = 0; c < results.length; c++) {
-			// optimization - only lookup standard concepts as non standard concepts will not have records
 			results[c].RECORD_COUNT = 0;
 			results[c].DESCENDANT_RECORD_COUNT = 0;
-			if (results[c].STANDARD_CONCEPT_CAPTION == 'Standard' || results[c].STANDARD_CONCEPT_CAPTION == 'Classification') {
-				searchResultIdentifiers.push(results[c].CONCEPT_ID);
-				resultsIndex.push(c);
-			}
+			searchResultIdentifiers.push(results[c].CONCEPT_ID);
+			resultsIndex.push(c);
 		}
 		return CDMResultAPI.getConceptRecordCountWithResultsUrl(sharedState.resultsUrl(), searchResultIdentifiers, results, false);
 	}


### PR DESCRIPTION
Requires changes from OHDSI/WebAPI#1039 and assumes you have run the Achilles analyses added as part of OHDSI/Achilles#393