### PR TITLE
Show 'allow events outside observation period' option in all cases.

### DIFF
--- a/js/components/cohortbuilder/components/CriteriaGroupTemplate.html
+++ b/js/components/cohortbuilder/components/CriteriaGroupTemplate.html
@@ -95,9 +95,8 @@
 
 								<div class="restrictVisitSection" data-bind="if: $component.hasVO($data.Criteria)">
 									<input type="checkbox" data-bind="checked: RestrictVisit"> restrict to the same visit occurrence<br/>
-									<input type="checkbox" data-bind="checked: IgnoreObservationPeriod"> allow events from outside observation period<br/>
 								</div>
-
+								<input type="checkbox" data-bind="checked: IgnoreObservationPeriod"> allow events from outside observation period<br/>
 							</div>
 						</td>
 						<td>


### PR DESCRIPTION
Moved the checkbox out of the 'restrictVo' div, which was causing it to be hidden for criteria that was not associated with a Visit Occurrence (such as condition era).
