### PR TITLE
Delete concept set - fixes #1750 - v2.7.2-rc

### DIFF
--- a/js/pages/concept-sets/conceptset-manager.js
+++ b/js/pages/concept-sets/conceptset-manager.js
@@ -303,7 +303,7 @@ define([
 			// reset view after save
 			conceptSetService.deleteConceptSet(this.model.currentConceptSet().id)
 				.then(() => {
-					this.model.currentConceptSet(null);
+					this.model.clearConceptSet();
 					document.location = "#/conceptsets"
 				});
 		}


### PR DESCRIPTION
Uses the model's clearConceptSet() method after deletion to remove stale references to fix #1750.