### PR TITLE
Concept set state fix after optimize - fixes #1751 - v2.7.2-rc

### DIFF
--- a/js/pages/concept-sets/conceptset-manager.js
+++ b/js/pages/concept-sets/conceptset-manager.js
@@ -343,6 +343,7 @@ define([
 				}
 				newConceptSet.push(newItem);
 			})
+			sharedState.clearSelectedConcepts();
 			this.selectedConcepts(newConceptSet);
 			this.isOptimizeModalShown(false);
 		}


### PR DESCRIPTION
Call `sharedState.clearSelectedConcepts()` when overwriting the current concept set through the optimize utility. Fixes #1751.