### PR TITLE
Remove duplication in data source table - #913

### DIFF
--- a/js/pages/data-sources/classes/Treemap.js
+++ b/js/pages/data-sources/classes/Treemap.js
@@ -135,12 +135,12 @@ define([
 			const normalizedData = atlascharts.chart.normalizeDataframe(ChartUtils.normalizeArray(data, true));
 
 			if (!normalizedData.empty) {
-				let distinctConceptIds = [];
+				let distinctConceptIds = new Set([]);
 				let tableData = [];
 				// Make the values unique per https://github.com/OHDSI/Atlas/issues/913
 				normalizedData.conceptPath.forEach((d, i) => {
-					if (!distinctConceptIds.includes(normalizedData.conceptId[i])) {
-						distinctConceptIds.push(normalizedData.conceptId[i]);
+					if (!distinctConceptIds.has(normalizedData.conceptId[i])) {
+						distinctConceptIds.add(normalizedData.conceptId[i]);
 						const pathParts = d.split('||');
 						tableData.push({
 							concept_id: normalizedData.conceptId[i],

--- a/js/pages/data-sources/classes/Treemap.js
+++ b/js/pages/data-sources/classes/Treemap.js
@@ -135,18 +135,24 @@ define([
 			const normalizedData = atlascharts.chart.normalizeDataframe(ChartUtils.normalizeArray(data, true));
 
 			if (!normalizedData.empty) {
-				const tableData = normalizedData.conceptPath.map((d, i) => {
-					const pathParts = d.split('||');
-					return {
-						concept_id: normalizedData.conceptId[i],
-						name: pathParts[pathParts.length - 1],
-						ingredient: pathParts[3],
-						num_persons: ChartUtils.formatComma(normalizedData.numPersons[i]),
-						percent_persons: ChartUtils.formatPercent(normalizedData.percentPersons[i]),
-						agg_value: ChartUtils.formatFixed(normalizedData[this.aggProperty.name][i])
-					};
+				let distinctConceptIds = [];
+				let tableData = [];
+				// Make the values unique per https://github.com/OHDSI/Atlas/issues/913
+				normalizedData.conceptPath.forEach((d, i) => {
+					if (!distinctConceptIds.includes(normalizedData.conceptId[i])) {
+						distinctConceptIds.push(normalizedData.conceptId[i]);
+						const pathParts = d.split('||');
+						tableData.push({
+							concept_id: normalizedData.conceptId[i],
+							name: pathParts[pathParts.length - 1],
+							ingredient: pathParts[3],
+							num_persons: ChartUtils.formatComma(normalizedData.numPersons[i]),
+							percent_persons: ChartUtils.formatPercent(normalizedData.percentPersons[i]),
+							agg_value: ChartUtils.formatFixed(normalizedData[this.aggProperty.name][i])
+						});
+					}
 				});
-				this.tableData(tableData);
+				this.tableData(tableData); 
 				this.treeData(normalizedData);
 
 				return {


### PR DESCRIPTION
Ensures that only unique entries are shown in the table display for the data sources "treemap" reports. For example, before this PR, here's how the table display looks like for the drug exposure report for concept_id == 19080128

![image](https://user-images.githubusercontent.com/12902366/58573904-bfc3a800-820c-11e9-8bcb-8ea7da7628cb.png)

and after:

![image](https://user-images.githubusercontent.com/12902366/58573932-d1a54b00-820c-11e9-8d06-c1960779ebdd.png)

This is using the approach described in issue https://github.com/OHDSI/Atlas/issues/913#issuecomment-496967558