### PR TITLE
Issue 1571 [v2.7.2]

### DIFF
--- a/js/components/cohort-definition-browser.html
+++ b/js/components/cohort-definition-browser.html
@@ -1,4 +1,4 @@
-<faceted-datatable data-bind="visible:loading()==false" params="orderColumn: 3, reference:reference, columns: columns, options:options, rowClick:rowClick">
+<faceted-datatable data-bind="visible:loading()==false" params="orderColumn: 3, autoWidth: false, reference:reference, columns: columns, options:options, rowClick:rowClick">
 </faceted-datatable>
 
 <loading data-bind="visible:loading()" params="status: 'retrieving cohort definitions'"></loading>

--- a/js/components/cohort-definition-browser.js
+++ b/js/components/cohort-definition-browser.js
@@ -31,9 +31,19 @@ define([
 			this.loading(true);
 
 			httpService.doGet(`${config.api.url}cohortdefinition`)
-				.then(({ data }) => this.reference(data))
+				.then(({ data }) => {
+					let defList = data.map(d => {
+						return {
+							...d, 
+							...{
+								createdTimestamp: d.createdDate && new Date(d.createdDate).getTime(),
+								modifiedTimestamp: d.modifiedDate && new Date(d.modifiedDate).getTime()
+							}
+						};
+					});
+					this.reference(defList);
+				})
 				.finally(() => { this.loading(false) });
-
 
 			this.options = {
 				Facets: [{
@@ -72,20 +82,21 @@ define([
 				},
 				{
 					title: 'Created',
-					type: 'datetime-formatted',
-					render: function (s, p, d) {
-						return momentApi.formatDateTimeUTC(d.createdDate);
+					className: 'dateColumn',
+					render: function (row, type, val, meta) {
+						return type === "sort" ? val.createdTimestamp : momentApi.formatDateTimeUTC(val.createdDate);
 					}
 				},
 				{
 					title: 'Updated',
-					type: 'datetime-formatted',
-					render: function (s, p, d) {
-						return momentApi.formatDateTimeUTC(d.modifiedDate);
+					className: 'dateColumn',
+					render: function (row, type, val, meta) {
+						return type === "sort" ? val.modifiedTimestamp : momentApi.formatDateTimeUTC(val.modifiedDate);
 					}
 				},
 				{
 					title: 'Author',
+					className: 'authorColumn',
 					render: datatableUtils.getCreatedByFormatter(),
 				}
 			];

--- a/js/components/cohort-definition-browser.js
+++ b/js/components/cohort-definition-browser.js
@@ -74,6 +74,7 @@ define([
 
 			this.columns = [{
 					title: 'Id',
+					className: 'id-column',
 					data: 'id'
 				},
 				{
@@ -82,21 +83,21 @@ define([
 				},
 				{
 					title: 'Created',
-					className: 'dateColumn',
+					className: 'date-column',
 					render: function (row, type, val, meta) {
 						return type === "sort" ? val.createdTimestamp : momentApi.formatDateTimeUTC(val.createdDate);
 					}
 				},
 				{
 					title: 'Updated',
-					className: 'dateColumn',
+					className: 'date-column',
 					render: function (row, type, val, meta) {
 						return type === "sort" ? val.modifiedTimestamp : momentApi.formatDateTimeUTC(val.modifiedDate);
 					}
 				},
 				{
 					title: 'Author',
-					className: 'authorColumn',
+					className: 'author-column',
 					render: datatableUtils.getCreatedByFormatter(),
 				}
 			];

--- a/js/components/faceted-datatable.js
+++ b/js/components/faceted-datatable.js
@@ -28,7 +28,7 @@ define(['knockout', 'text!./faceted-datatable.html', 'crossfilter', 'colvis', ],
 		self.drawCallback = params.drawCallback;
 
 		// Set some defaults for the data table
-		self.autoWidth = params.autoWidth || true;
+		self.autoWidth = params.autoWidth !== 'undefined' ? params.autoWidth : true;
 		self.buttons = params.buttons || [
 			'colvis',  'copyHtml5', 'excelHtml5', 'csvHtml5', 'pdfHtml5'
 		];

--- a/js/styles/atlas.css
+++ b/js/styles/atlas.css
@@ -32,12 +32,16 @@ table.cohort-generate-sources thead {
   width: calc(100%-1em)
 }
 
-td.dateColumn {
+td.date-column {
 	width: 125px;
 }
 
-td.authorColumn {
+td.author-column {
 	width: 125px;
+}
+
+td.id-column {
+	width: 45px;
 }
 
 .breadcrumb-container {

--- a/js/styles/atlas.css
+++ b/js/styles/atlas.css
@@ -32,6 +32,14 @@ table.cohort-generate-sources thead {
   width: calc(100%-1em)
 }
 
+td.dateColumn {
+	width: 125px;
+}
+
+td.authorColumn {
+	width: 125px;
+}
+
 .breadcrumb-container {
   background-color: #333;
   color: #fff;


### PR DESCRIPTION
2 Issues addressed:
1. Sorting a large table on date resulted in excessive date parsing and comparison.  The solution adds a new 'timestamp' column that is pre-calculated as an integer so sorting can be performed without parsing.

2. Added css classes to fix the created/updated and author columns.  This uses a fixed column width.  The reason this felt necessary was due to the following behavior:

Without fixed columns:
![before](https://user-images.githubusercontent.com/6818777/58575455-14b4ed80-8210-11e9-8700-bd0ceda04604.gif)

With fixed Columns:
![after](https://user-images.githubusercontent.com/6818777/58575461-18e10b00-8210-11e9-83ad-cf6ec5a1f349.gif)

Fixes #1571.
