### PR TITLE
Hide create cs button - fixes #1834 - master

### DIFF
--- a/js/pages/characterizations/components/characterizations/characterization-view-edit/characterization-results.js
+++ b/js/pages/characterizations/components/characterizations/characterization-view-edit/characterization-results.js
@@ -118,12 +118,17 @@ define([
                 });
             }
 
+           /*
+            * Taking this out per https://github.com/OHDSI/Atlas/issues/1834
+
            if (this.extractConceptIds(analysis).length > 0) {
                 buttons.push({
                     text: 'Create new Concept Set',
                     action: () => this.createNewSet(analysis)
                 });
             }
+
+            */
 
             return buttons;
         }


### PR DESCRIPTION
Hides the "Create new concept set" button from the characterization results display per #1834.