### PR TITLE
Specify concrete version of bootstrap-select since upcoming versions bring issues with flex markup (2.7.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@ohdsi/visibilityjs": "^2.0.2",
     "ajv": "^6.10.0",
     "bootstrap": "^3.3.7",
-    "bootstrap-select": "^1.13.3",
+    "bootstrap-select": "1.13.5",
     "bowser": "2.0.0-beta.3",
     "clipboard": "^1.5.16",
     "colorbrewer": "^1.3.0",


### PR DESCRIPTION
Fixes #1830