### PR TITLE
Add checks for concept set export - fixes #1853

### DIFF
--- a/js/pages/cohort-definitions/cohort-definition-manager.css
+++ b/js/pages/cohort-definitions/cohort-definition-manager.css
@@ -53,3 +53,7 @@
      width: 100%;
      height: 600px;
 }
+
+.cohort-conceptset-button-pane .btn-success.disabled {
+    color: #f3f3f3;
+}

--- a/js/pages/cohort-definitions/cohort-definition-manager.html
+++ b/js/pages/cohort-definitions/cohort-definition-manager.html
@@ -63,7 +63,7 @@
 				<div class="cohort-conceptset-button-pane pull-right">
 					<button type="button" class="btn btn-sm btn-primary" data-bind="click:function() { newConceptSet(); }, enable: canEdit">New Concept Set</button>
 					<button type="button" class="btn btn-sm btn-primary" data-bind="click:function(){ $component.importConceptSet() }, enable: canEdit"><i class="fa fa-upload" aria-hidden="true" /> Import</button>
-					<button type="button" class="btn btn-sm btn-success" data-bind="click:function() { exportConceptSetsCSV(); }, css: {'disabled': dirtyFlag().isDirty, 'btn-success': !dirtyFlag().isDirty()}"><i class="fa fa-download" aria-hidden="true"></i> Export All Concept Sets To CSV</button>
+					<span data-bind="tooltip: $component.disableConceptSetExport() ? $component.disableConceptSetExportMessage() : null" data-placement="bottom"><button type="button" class="btn btn-sm btn-success" data-bind="click:function() { exportConceptSetsCSV(); }, css: {'disabled': disableConceptSetExport}"><i class="fa fa-download" aria-hidden="true"></i> Export All Concept Sets To CSV</button></span>
 				</div>
 				<table class="conceptSetTable stripe compact hover" cellspacing="0" width="100%" data-bind="dataTable:{
 											data: $root.currentCohortDefinition() && $root.currentCohortDefinition().expression().ConceptSets,

--- a/js/pages/cohort-definitions/cohort-definition-manager.js
+++ b/js/pages/cohort-definitions/cohort-definition-manager.js
@@ -239,6 +239,19 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 				return this.dirtyFlag().isDirty() && !this.isRunning() && this.canEdit() && this.isNameCorrect();
 			});
 
+			this.disableConceptSetExport = ko.pureComputed(() => {
+				return this.dirtyFlag().isDirty() || this.model.currentCohortDefinition().expression().ConceptSets().length === 0;
+			});
+
+			this.disableConceptSetExportMessage = ko.pureComputed(() => {
+				if (this.model.currentCohortDefinition().expression().ConceptSets().length === 0) {
+					return "No concept sets to export.";
+				}
+				if (this.dirtyFlag().isDirty()) {
+					return "You must save the definition before you can export.";
+				}
+			})
+
 			this.delayedCartoonUpdate = ko.observable(null);
 
 			this.saveConceptSetShow = ko.observable(false);


### PR DESCRIPTION
Prevent a user from exporting all concept sets from a cohort definition until there is at least 1 concept set in the definition and the definition has been saved to the server. Also added a warning message to indicate why the button is disabled.

fixes #1853