### PR TITLE
Fix polling delay in IR - fixes #1883

### DIFF
--- a/js/pages/incidence-rates/ir-manager.js
+++ b/js/pages/incidence-rates/ir-manager.js
@@ -461,7 +461,7 @@ define([
 
 		async init() {
 			this.refreshDefs();
-			const sources = await sourceAPI.getSources();
+			const sources = sharedState.sources();
 			const sourceList = [];
 			sources.forEach(source => {
 				if (source.daimons.filter(function (daimon) {

--- a/js/pages/incidence-rates/ir-manager.js
+++ b/js/pages/incidence-rates/ir-manager.js
@@ -111,6 +111,12 @@ define([
 			this.sources = ko.observableArray();
 			this.stoppingSources = ko.observable({});
 
+			this.canStartPolling = ko.computed(() => {
+				if (this.sources().length > 0 && this.selectedAnalysis() && this.selectedAnalysis().id() > 0) {
+					this.startPolling();
+				} 
+			});
+
 			this.cohortDefs = ko.observableArray();
 			this.analysisCohorts = ko.pureComputed(() => {
 				var analysisCohorts = {targetCohorts: ko.observableArray(), outcomeCohorts: ko.observableArray()};
@@ -277,7 +283,6 @@ define([
 				this.selectedAnalysis(new IRAnalysisDefinition(analysis));
 				this.dirtyFlag(new ohdsiUtil.dirtyFlag(this.selectedAnalysis()));
 				this.loading(false);
-				this.startPolling();
 			});
 		}
 
@@ -285,11 +290,12 @@ define([
 			const { analysisId } = params;
 			if (analysisId && parseInt(analysisId) !== (this.selectedAnalysis() && this.selectedAnalysis().id())) {
 				this.onAnalysisSelected();
-			} else if (this.selectedAnalysis() && this.selectedAnalysis().id()) {
-				this.startPolling();
 			}
 		}
 
+		// startPolling is called once the conditions
+		// in the computed observable canStartPolling
+		// are satisfied
 		startPolling() {
 			this.pollId = PollService.add({
 				callback: silently => this.pollForInfo({ silently }),

--- a/js/pages/incidence-rates/ir-manager.js
+++ b/js/pages/incidence-rates/ir-manager.js
@@ -111,12 +111,6 @@ define([
 			this.sources = ko.observableArray();
 			this.stoppingSources = ko.observable({});
 
-			this.canStartPolling = ko.computed(() => {
-				if (this.sources().length > 0 && this.selectedAnalysis() && this.selectedAnalysis().id() > 0) {
-					this.startPolling();
-				} 
-			});
-
 			this.cohortDefs = ko.observableArray();
 			this.analysisCohorts = ko.pureComputed(() => {
 				var analysisCohorts = {targetCohorts: ko.observableArray(), outcomeCohorts: ko.observableArray()};
@@ -283,6 +277,7 @@ define([
 				this.selectedAnalysis(new IRAnalysisDefinition(analysis));
 				this.dirtyFlag(new ohdsiUtil.dirtyFlag(this.selectedAnalysis()));
 				this.loading(false);
+				this.startPolling();
 			});
 		}
 
@@ -290,12 +285,11 @@ define([
 			const { analysisId } = params;
 			if (analysisId && parseInt(analysisId) !== (this.selectedAnalysis() && this.selectedAnalysis().id())) {
 				this.onAnalysisSelected();
+			} else if (this.selectedAnalysis() && this.selectedAnalysis().id()) {
+				this.startPolling();
 			}
 		}
 
-		// startPolling is called once the conditions
-		// in the computed observable canStartPolling
-		// are satisfied
 		startPolling() {
 			this.pollId = PollService.add({
 				callback: silently => this.pollForInfo({ silently }),
@@ -465,7 +459,7 @@ define([
 			}
 		}
 
-		async init() {
+		init() {
 			this.refreshDefs();
 			const sources = sharedState.sources();
 			const sourceList = [];


### PR DESCRIPTION
Could use some feedback from @chrisknoll @pavgra on this.

Here is the issue: when the `js/pages/incidence-rates/ir-manager.js` component is loaded, the `init()` is called asynchronously. Before the changes in this PR, this would call the WebAPI's sources endpoint to retrieve the sources and find those that are configured with both a CDM & Results daimon. With the changes I've made in this PR, this information will be retrieved from the `sharedState` thus preventing a round-trip to the server. 

There is still a potential race condition here: in the case of #1883, the IR analysis is already loaded such that when the `onRouterParamsChanged` function is called, it will automatically start polling for updates to the source. Within the `pollForInfo` function, it requires that the sources with a CDM & results daimon exists in order to display the summary of results. So, my fix here is potentially incomplete in the rare case that the source list cannot be parsed before the polling for information starts.

I think the proper approach is to start polling after the sources are initialized and the selected IR analysis is loaded. There could be a computed observable that then kicks off the polling instead of having the upstream callers start it. What do you think?