### PR TITLE
Fix quick analysis IDs; fix typos in report mgr

### DIFF
--- a/js/pages/cohort-definitions/components/reporting/cost-utilization/report-manager.js
+++ b/js/pages/cohort-definitions/components/reporting/cost-utilization/report-manager.js
@@ -2642,7 +2642,7 @@ define([
 
 							// create svg with range bands based on the trellis names
 							let chart = new atlascharts.trellisline();
-							const size = this.breakpoints.guessFromNode("#conditoinera_trellisLinePlot");
+							const size = this.breakpoints.guessFromNode("#conditionera_trellisLinePlot");
 							chart.render(dataByDecile, "#conditionera_trellisLinePlot", size.width, this.breakpoints.wide.height, {
 								trellisSet: allDeciles,
 								trellisLabel: "Age Decile",
@@ -2762,7 +2762,7 @@ define([
 							// create svg with range bands based on the trellis names
 							let chart = new atlascharts.trellisline();
 							const size = this.breakpoints.guessFromNode("#drugera_trellisLinePlot");
-							chart.render(dataByDecile, "#drugera_trellisLinePlot", size.width, size.breakpoints.wide.height, {
+							chart.render(dataByDecile, "#drugera_trellisLinePlot", size.width, this.breakpoints.wide.height, {
 								trellisSet: allDeciles,
 								trellisLabel: "Age Decile",
 								seriesLabel: "Year of Observation",

--- a/js/services/CohortReporting.js
+++ b/js/services/CohortReporting.js
@@ -24,7 +24,7 @@ define(function (require, exports) {
       name: "Condition Eras",
       reportKey: 'Condition Eras',
       // analyses: [1001, 1000, 1007, 1006, 1004, 1002, 116, 117, 1]
-      analyses: [1, 1000, 1007] // allows for quick analysis minimum requirements
+      analyses: [1, 1000, 1002, 1004, 1006, 1007] // allows for quick analysis minimum requirements
     },
     conditionByIndex: {
       name: "Conditions by Index",
@@ -50,7 +50,7 @@ define(function (require, exports) {
       name: "Drug Eras",
       reportKey: 'Drug Eras',
       // analyses: [900, 901, 907, 906, 904, 902, 116, 117, 1]
-      analyses: [1, 900, 907] // allows for quick analysis minimum requirements
+      analyses: [1, 900, 902, 904, 906, 907] // allows for quick analysis minimum requirements
     },
     drugExposure: {
       name: "Drug Exposure",


### PR DESCRIPTION
This is a fix for OHDSI/WebAPI#933. It should be tested in conjunction with https://github.com/OHDSI/WebAPI/pull/1194.

I've added the additional Heracles analysis IDs that are required to display all of the results for the condition & drug era reports run during the "Quick Analysis" for cohort reporting in `js/services/CohortReporting.js`.  Additionally I fixed some typos that were preventing proper rendering of the cohort & drug era reports in `js/pages/cohort-definitions/components/reporting/cost-utilization/report-manager.js`. 