### PR TITLE
Update ATC heading display - fixes #1872

### DIFF
--- a/js/pages/cohort-definitions/components/reporting/cost-utilization/report-manager.html
+++ b/js/pages/cohort-definitions/components/reporting/cost-utilization/report-manager.html
@@ -310,7 +310,7 @@
 									<th>Concept Id</th>
 									<th>ATC 1</th>
 									<th>ATC 3</th>
-									<th>ATC 5</th>
+									<th>ATC 4</th>
 									<th>Ingredient</th>
 									<th>Person Count</th>
 									<th>Prevalence</th>
@@ -690,7 +690,7 @@
 									<th>Concept Id</th>
 									<th>ATC 1</th>
 									<th>ATC 3</th>
-									<th>ATC 5</th>
+									<th>ATC 4</th>
 									<th>Ingredient</th>
 									<th>Person Count</th>
 									<th>Prevalence</th>
@@ -773,7 +773,7 @@
 									<th>Concept Id</th>
 									<th>ATC 1</th>
 									<th>ATC 3</th>
-									<th>ATC 5</th>
+									<th>ATC 4</th>
 									<th>Ingredient</th>
 									<th>RxNorm</th>
 									<th>Person Count</th>


### PR DESCRIPTION
This pull request requires the corresponding changes in https://github.com/OHDSI/WebAPI/pull/1195. Revising the WebAPI queries corrects the problem noted in issue #1872.

During the investigation of #1872, I noted that the display in the cohort reporting for Drug reports is incorrect. Per the [concept_hierarchy construction](https://github.com/OHDSI/WebAPI/blob/master/src/main/resources/ddl/results/init_concept_hierarchy.sql#L171), the display should be **ATC 4th**. 