### PR TITLE
Fixed render of cc covariate name

### DIFF
--- a/js/pages/characterizations/components/characterizations/characterization-view-edit/characterization-results.js
+++ b/js/pages/characterizations/components/characterizations/characterization-view-edit/characterization-results.js
@@ -321,6 +321,7 @@ define([
                         covariateName: r.covariateName,
                         conceptId: r.conceptId,
                         conceptName: r.conceptName,
+                        faType: r.faType,
                         avg: r.avg,
                         count: r.count,
                         pct: r.avg * 100,

--- a/js/pages/characterizations/components/characterizations/characterization-view-edit/explore-prevalence.js
+++ b/js/pages/characterizations/components/characterizations/characterization-view-edit/explore-prevalence.js
@@ -30,7 +30,7 @@ define([
 			this.tableColumns = [
 				{ title: 'Relationship type', render: this.renderRelationship, class: this.classes('col-type'), },
 				{ title: 'Distance', data: 'distance', class: this.classes('col-distance'), },
-				{ title: 'Concept name', data: 'covariateName', class: this.classes('col-concept'), render: (d, t, r) => pageUtils.extractMeaningfulCovName(d) },
+				{ title: 'Concept name', data: 'covariateName', class: this.classes('col-concept'), render: (d, t, { covariateName, faType }) =>  pageUtils.extractMeaningfulCovName(covariateName, faType) },
 			];
 			this.data = ko.observableArray();
 			this.loading = ko.observable();
@@ -121,7 +121,7 @@ define([
 
 			return buttons;
 		}
-		
+
 		exportTable() {
 			const exprt = this.relations().stats.map(stat => {
 				return ({
@@ -133,7 +133,7 @@ define([
 					'Strata ID': stat.strataId,
 					'Strata name': stat.strataName,
 					'Analysis ID': stat.analysisId,
-					'Analysis name': stat.analysisName,					
+					'Analysis name': stat.analysisName,
 					'Covariate ID': stat.covariateId,
 					'Covariate name': stat.covariateName
 				});
@@ -153,7 +153,7 @@ define([
 			const binding = distance !== 0 ? 'click: () => $component.exploreByFeature({...$data, cohortId: $component.cohortId})' : '';
 			return "<a class='"+ cls + "' data-bind='" + binding + "'>Explore</a> " + rel;
 		}
-		
+
 		getRelationshipTypeFromDistance(distance) {
 			return distance > 0 ? 'Ancestor' : distance < 0 ? 'Descendant' : 'Selected';
 		}

--- a/js/pages/characterizations/components/feature-analyses/const.js
+++ b/js/pages/characterizations/components/feature-analyses/const.js
@@ -2,11 +2,15 @@ define((require, exports) => {
 
 	const constants = require('pages/characterizations/const');
 	const datatableUtils = require('utils/DatatableUtils');
-
+	const feAnalysisTypes = {
+		PRESET: 'Preset',
+		CRITERIA_SET: 'Criteria set',
+		CUSTOM_FE: 'Custom'
+	};
 	const FeatureAnalysisFacets = [
 		{
 			'caption': 'Type',
-			'binding': (o) => constants.feAnalysisTypes[o.type]
+			'binding': (o) => feAnalysisTypes[o.type]
 		},
 		{
 			'caption': 'Domain',

--- a/js/pages/characterizations/const.js
+++ b/js/pages/characterizations/const.js
@@ -25,12 +25,12 @@ define(
         const ccGenerationStatus = consts.generationStatuses;
 
         const feAnalysisTypes = {
-            PRESET: 'Preset',
-            CRITERIA_SET: 'Criteria set',
-            CUSTOM_FE: 'Custom'
+            PRESET: 'PRESET',
+            CRITERIA: 'CRITERIA',
+            CUSTOM_FE: 'CUSTOM_FE'
         };
 
-        const demoCustomSqlAnalysisDesign = `-- Custom analysis producing same results as Feature Extraction's "One covariate per drug in the drug_era table overlapping with any time prior to index." 
+        const demoCustomSqlAnalysisDesign = `-- Custom analysis producing same results as Feature Extraction's "One covariate per drug in the drug_era table overlapping with any time prior to index."
 SELECT
   CAST(drug_concept_id AS BIGINT) * 1000 + @analysis_id AS covariate_id,
   c.concept_name                                                                  AS covariate_name,

--- a/js/pages/characterizations/services/conversion/PrevalenceStat.js
+++ b/js/pages/characterizations/services/conversion/PrevalenceStat.js
@@ -11,6 +11,7 @@ define([
 			this.conceptId = stat.conceptId;
 			this.conceptName = stat.conceptName;
 			this.domainId = stat.domainId;
+			this.faType = stat.faType;
 			this.cohorts = [];
 			this.count = {};
 			this.pct = {};

--- a/js/pages/characterizations/services/conversion/PrevalenceStatConverter.js
+++ b/js/pages/characterizations/services/conversion/PrevalenceStatConverter.js
@@ -58,9 +58,7 @@ define([
                 title: 'Covariate',
                 data: 'covariateName',
                 className: this.classes('col-prev-title'),
-                render: (d, t, r) => {
-                    return utils.extractMeaningfulCovName(d);
-                 },
+                render: (d, t, { covariateName, faType }) => utils.extractMeaningfulCovName(covariateName, faType),
             };
         }
 

--- a/js/pages/characterizations/utils.js
+++ b/js/pages/characterizations/utils.js
@@ -2,10 +2,12 @@ define([
 	'knockout',
 	'services/Vocabulary',
 	'conceptsetbuilder/InputTypes/ConceptSet',
+	'./const',
 ], function (
 	ko,
 	VocabularyAPI,
 	ConceptSet,
+	constants,
 ) {
 
 	function conceptSetSelectionHandler(conceptSets, context, selection, source) {
@@ -23,7 +25,10 @@ define([
 
 	}
 
-	function extractMeaningfulCovName(fullName) {
+	function extractMeaningfulCovName(fullName, faType = constants.feAnalysisTypes.CRITERIA) {
+		if ([constants.feAnalysisTypes.CRITERIA, constants.feAnalysisTypes.CUSTOM_FE].includes(faType)) {
+			return fullName;
+		}
 		let nameParts = fullName.split(":");
 		if (nameParts.length < 2) {
 			nameParts = fullName.split("=");


### PR DESCRIPTION
Fixes #1926 

As discussed with @pavgra CC covariate name will stay original if faType is CUSTOM_FE/CRITERIA.