### PR TITLE
Optimize concept set fix (#1930)

### DIFF
--- a/js/Model.js
+++ b/js/Model.js
@@ -465,7 +465,7 @@ define(
 			setConceptSet(conceptset, expressionItems) {
 				var conceptSetItemsToAdd = [];
 				expressionItems.forEach((conceptSet) => {
-					const conceptSetItem = conceptSetService.enchanceConceptSet(conceptSet);
+					const conceptSetItem = conceptSetService.enhanceConceptSet(conceptSet);
 
 					sharedState.selectedConceptsIndex[conceptSetItem.concept.CONCEPT_ID] = 1;
 					conceptSetItemsToAdd.push(conceptSetItem);

--- a/js/pages/concept-sets/conceptset-manager.js
+++ b/js/pages/concept-sets/conceptset-manager.js
@@ -333,12 +333,10 @@ define([
 		}
 
 		overwriteConceptSet() {
-			var newConceptSet = [];
 			sharedState.clearSelectedConcepts();
-			this.optimalConceptSet().forEach((item) => {
-				let newItem = conceptSetService.enhanceConceptSet(item);
+			const newConceptSet = this.optimalConceptSet().map((item) => {
 				sharedState.selectedConceptsIndex[item.concept.CONCEPT_ID] = 1;
-				newConceptSet.push(newItem);
+				return conceptSetService.enhanceConceptSet(item);
 			});
 			sharedState.selectedConcepts(newConceptSet);
 			this.isOptimizeModalShown(false);
@@ -354,20 +352,18 @@ define([
 		}
 
 		saveNewOptimizedConceptSet() {
-			var conceptSet = {};
-			conceptSet.id = 0;
-			conceptSet.name = this.optimizerSavingNewName;
-			var selectedConcepts = [];
-			this.optimalConceptSet().forEach((item) => {
-				var newItem;
-				newItem = {
+			const conceptSet = {
+				id: 0,
+				name: this.optimizerSavingNewName,
+			};
+			const selectedConcepts = this.optimalConceptSet().map((item) => (
+				{
 					concept: item.concept,
 					isExcluded: ko.observable(item.isExcluded),
 					includeDescendants: ko.observable(item.includeDescendants),
 					includeMapped: ko.observable(item.includeMapped),
 				}
-				selectedConcepts.push(newItem);
-			});
+			));
 			this.saveConceptSet("#txtOptimizerSavingNewName", conceptSet, selectedConcepts);
 			this.optimizerSavingNew(false);
 			this.isOptimizeModalShown(false);

--- a/js/pages/concept-sets/conceptset-manager.js
+++ b/js/pages/concept-sets/conceptset-manager.js
@@ -334,20 +334,16 @@ define([
 
 		overwriteConceptSet() {
 			var newConceptSet = [];
-			this.optimalConceptSet().forEach((item) => {
-				var newItem;
-				newItem = {
-					concept: item.concept,
-					isExcluded: ko.observable(item.isExcluded),
-					includeDescendants: ko.observable(item.includeDescendants),
-					includeMapped: ko.observable(item.includeMapped),
-				}
-				newConceptSet.push(newItem);
-			})
 			sharedState.clearSelectedConcepts();
-			this.selectedConcepts(newConceptSet);
+			this.optimalConceptSet().forEach((item) => {
+				let newItem = conceptSetService.enhanceConceptSet(item);
+				sharedState.selectedConceptsIndex[item.concept.CONCEPT_ID] = 1;
+				newConceptSet.push(newItem);
+			});
+			sharedState.selectedConcepts(newConceptSet);
 			this.isOptimizeModalShown(false);
 		}
+
 		copyOptimizedConceptSet () {
 			if (this.model.currentConceptSet() == undefined) {
 				this.optimizerSavingNewName(this.conceptSetName());

--- a/js/services/ConceptSet.js
+++ b/js/services/ConceptSet.js
@@ -48,7 +48,7 @@ define(function (require, exports) {
 		};
 	}
 
-	function enchanceConceptSet(conceptSetItem) {
+	function enhanceConceptSet(conceptSetItem) {
 		return {
 			...conceptSetItem,
 			isExcluded: ko.observable(conceptSetItem.isExcluded),
@@ -122,7 +122,7 @@ define(function (require, exports) {
 		getIncludedConceptSetDrawCallback: getIncludedConceptSetDrawCallback,
 		getAncestorsModalHandler: getAncestorsModalHandler,
 		getAncestorsRenderFunction: getAncestorsRenderFunction,
-		enchanceConceptSet,
+		enhanceConceptSet,
 		loadConceptSet,
 		loadConceptSetExpression,
 		lookupIdentifiers,


### PR DESCRIPTION
Fixes issue #1930 by ensuring that the newly optimized concepts are added to the shared state collection:

`sharedState.selectedConceptsIndex[item.concept.CONCEPT_ID] = 1;`

Also done here:

- Corrected the spelling of enhanceConceptSet in `js/services/ConceptSet.js` and carried through the proper function name in the code base where applicable
- Used enhanceConceptSet in favor of the code that was duplicated in the function `overwriteConceptSet` (js/pages/concept-sets/conceptset-manager.js)