### PR TITLE
Fixed configuration and source manager pages

### DIFF
--- a/js/components/atlas-state.js
+++ b/js/components/atlas-state.js
@@ -69,5 +69,11 @@ define(['knockout', 'lscache', 'services/job/jobDetail', 'assets/ohdsi.util', 'c
 	}
 	state.predictionAnalysis.dirtyFlag = ko.observable(new ohdsiUtil.dirtyFlag(state.predictionAnalysis.current()));
 
+	state.ConfigurationSource = {
+		current: ko.observable(null),
+		selectedId: ko.observable(null),
+	}
+	state.ConfigurationSource.dirtyFlag = ko.observable(new ohdsiUtil.dirtyFlag(state.ConfigurationSource.current()));
+
 	return state;
 });

--- a/js/pages/configuration/configuration.html
+++ b/js/pages/configuration/configuration.html
@@ -1,6 +1,7 @@
 <heading-title params="name: 'Configuration', icon: 'cogs', theme: 'dark'"></heading-title>
 <div data-bind="if: $component.hasPageAccess(), css: classes({ extra: 'paddedWrapper' })">
-		<div data-bind="if: $component.initializationCompleted()">
+		<loading data-bind="visible:loading()"></loading>
+		<div data-bind="if: $component.initializationCompleted() && !loading()">
 			<div data-bind="with:config.api">
 				<div class="configureHeader">
 					<div class="left">

--- a/js/pages/configuration/configuration.js
+++ b/js/pages/configuration/configuration.js
@@ -41,9 +41,9 @@ define([
         {name: 'Current Session', id: 'session'},
         {name: 'Whole Application', id: 'application'},
       ];
-  
+
       this.isAuthenticated = authApi.isAuthenticated;
-      this.initializationCompleted = ko.pureComputed(() => sharedState.appInitializationStatus() === constants.applicationStatuses.running || 
+      this.initializationCompleted = ko.pureComputed(() => sharedState.appInitializationStatus() === constants.applicationStatuses.running ||
           sharedState.appInitializationStatus() === constants.applicationStatuses.noSourcesAvailable);
       this.hasSourceAccess = authApi.hasSourceAccess;
       this.hasPageAccess = ko.pureComputed(() => {
@@ -66,7 +66,7 @@ define([
           return (config.userAuthenticationEnabled && this.isAuthenticated() && authApi.isPermittedEditSourcePriority())
         }
       });
-      
+
 		  this.canImport = ko.pureComputed(() => this.isAuthenticated() && authApi.isPermittedImportUsers());
 
       this.intervalId = PollService.add({
@@ -121,14 +121,14 @@ define([
         return (config.userAuthenticationEnabled && this.isAuthenticated() && authApi.hasSourceAccess(source.sourceKey));
       }
     }
-    
+
 		clearLocalStorageCache() {
 			localStorage.clear();
 			alert("Local Storage has been cleared.  Please refresh the page to reload configuration information.")
 		};
 
 		newSource() {
-			document.location = "#/source/new";
+      commonUtils.routeTo('/source/0');
     };
 
 		selectSource(source) {
@@ -145,7 +145,7 @@ define([
         sourceApi.initSourcesConfig();
       } catch(err) {
         alert('Failed to update priority source daimon');
-      }        
+      }
       this.isInProgress(false);
     }
 

--- a/js/pages/configuration/configuration.js
+++ b/js/pages/configuration/configuration.js
@@ -32,6 +32,7 @@ define([
       super(params);
       this.config = config;
       this.api = config.api;
+      this.loading = ko.observable(false);
       this.sharedState = sharedState;
       this.isInProgress = ko.observable(false);
       this.jobListing = sharedState.jobListing;
@@ -94,8 +95,10 @@ define([
     }
 
     async onPageCreated() {
-      sourceApi.initSourcesConfig();
+      this.loading(true);
+      await sourceApi.initSourcesConfig();
       super.onPageCreated();
+      this.loading(false);
     }
 
     canReadSource(source) {

--- a/js/pages/configuration/index.js
+++ b/js/pages/configuration/index.js
@@ -1,13 +1,28 @@
 define(
   (require, exports) => {
+    const ko = require('knockout');
+    const appState = require('atlas-state');
     const buildRoutes = require('./routes');
+
+    const statusCss = ko.pureComputed(() => {
+      if (appState.ConfigurationSource.current()) {
+        return appState.ConfigurationSource.dirtyFlag().isDirty() ? 'unsaved' : 'open';
+      }
+      return '';
+    });
+
+    const navUrl = ko.pureComputed(() => {
+      return appState.ConfigurationSource.current()
+        ? `#/source/${(appState.ConfigurationSource.selectedId() || 0)}`
+        : '#/configure';
+    });
 
     return {
       title: 'Configuration',
       buildRoutes,
-      navUrl: () => '#/configure',
+      navUrl,
       icon: 'cogs',
-			statusCss: () => ''
+      statusCss,
     };
   }
 );

--- a/js/pages/configuration/routes.js
+++ b/js/pages/configuration/routes.js
@@ -1,5 +1,6 @@
 define(
 	(require, factory) => {
+    const atlasState = require('atlas-state');
     const { AuthorizedRoute } = require('pages/Route');
     function routes(appModel, router) {
       const JobViewEdit = new AuthorizedRoute((id, section) => {
@@ -53,11 +54,11 @@ define(
             router.setCurrentView('role-import');
           });
         }),
-        '/source/:id': new AuthorizedRoute((id) => {
+        '/source/:id': new AuthorizedRoute((sourceId) => {
           appModel.activePage(this.title);
           require(['./sources/source-manager'], function () {
-            appModel.selectedSourceId(id !== 'new' ? id : null);
-            router.setCurrentView('source-manager');
+            atlasState.ConfigurationSource.selectedId(sourceId);
+            router.setCurrentView('source-manager', { sourceId });
           });
         }),
       };

--- a/js/pages/configuration/sources/source-manager.js
+++ b/js/pages/configuration/sources/source-manager.js
@@ -1,7 +1,7 @@
 define([
   'knockout',
   'text!./source-manager.html',
-  'components/Component',
+  'pages/Page',
   'utils/AutoBind',
   'utils/CommonUtils',
   'appConfig',
@@ -20,7 +20,7 @@ define([
   function (
     ko,
     view,
-    Component,
+    Page,
     AutoBind,
     commonUtils,
     config,
@@ -68,6 +68,7 @@ define([
 
     var data = data || {};
 
+    this.sourceId = ko.observable(data.sourceId || 0);
     this.name = ko.observable(data.sourceName || "New Source");
     this.key = ko.observable(data.sourceKey || null);
     this.dialect = ko.observable(data.sourceDialect || null);
@@ -82,15 +83,15 @@ define([
     return this;
   }
 
-  class SourceManager extends AutoBind(Component) {
+  class SourceManager extends AutoBind(Page) {
     constructor(params) {
       super(params);
       this.config = config;
       this.model = params.model;
       this.loading = ko.observable(false);
-      this.dirtyFlag = this.model.currentSourceDirtyFlag;
-      this.selectedSource = params.model.currentSource;
-      this.selectedSourceId = params.model.selectedSourceId;
+      this.dirtyFlag = sharedState.ConfigurationSource.dirtyFlag;
+      this.selectedSource = sharedState.ConfigurationSource.current;
+      this.selectedSourceId = sharedState.ConfigurationSource.selectedId;
       this.options = {};
       this.isAuthenticated = authApi.isAuthenticated;
 
@@ -117,7 +118,9 @@ define([
       this.isNameCorrect = ko.computed(() => {
           return this.selectedSource() && this.selectedSource().name();
       });
-
+      this.isNew = ko.pureComputed(() => {
+        return parseInt(this.selectedSourceId()) === 0;
+      })
       this.canSave = ko.pureComputed(() => {
         return (
           this.isNameCorrect()
@@ -130,14 +133,13 @@ define([
       this.canDelete = () => {
         return (
           this.selectedSource()
+          && !this.isNew()
           && this.selectedSource().key()
           && this.isDeletePermitted()
         );
       };
 
-      this.canEditKey = ko.pureComputed(() => {
-        return !this.selectedSourceId();
-      });
+      this.canEditKey = ko.pureComputed(this.isNew);
 
       this.options.dialectOptions = [
         { name: 'PostgreSQL', id: 'postgresql' },
@@ -151,7 +153,7 @@ define([
       ];
 
       this.sourceCaption = ko.computed(() => {
-        return (this.model.currentSource() == null || this.model.currentSource().key() == null) ? 'New source' : 'Source ' + this.model.currentSource().name();
+        return (this.selectedSource() == null || this.selectedSource().key() == null) ? 'New source' : `Source ${this.selectedSource().name()}`;
       });
       this.isKrbAuth = ko.computed(() => {
           return this.impalaConnectionStringIncludes("AuthMech=1");
@@ -186,7 +188,7 @@ define([
         }
         return "";
       });
-      this.init();
+
       this.fieldsVisibility = {
         username: ko.computed(() => !this.supportsKeyfileAuth() || this.isKrbAuth()),
         password: ko.computed(() => !this.supportsKeyfileAuth()),
@@ -279,7 +281,8 @@ define([
       };
       try {
         this.loading(true);
-        await sourceApi.saveSource(this.selectedSourceId(), source);
+        const sourceId = this.isNew() ? null : this.selectedSourceId();
+        await sourceApi.saveSource(sourceId, source);
         const appStatus = await sourceApi.initSourcesConfig();
         sharedState.appInitializationStatus(appStatus);
         await vocabularyProvider.getDomains();
@@ -316,7 +319,7 @@ define([
 		return notSelectedCurrentDaimons.length !== currenPriotirizableDaimons.length;
     }
 
-    delete() {
+    async delete() {
       if (this.hasSelectedPriotirizableDaimons()) {
         alert('Some daimons of this source were given highest priority and are in use by application. Select new top-priority diamons to delete the source');
         return;
@@ -325,41 +328,50 @@ define([
       if (!confirm('Delete source? Warning: deletion can not be undone!')) {
         return;
       }
-      this.loading(true);
-      sourceApi.deleteSource(this.selectedSourceId())
-        .then(sourceApi.initSourcesConfig)
-        .then(function (appStatus) {
-            sharedState.appInitializationStatus(appStatus);
-            return roleService.getList();
-        })
-        .then((roles) => {
-          this.model.roles(roles);
-          this.loading(false);
-          this.goToConfigure();
-        })
-        .catch(() => this.loading(false));
-    }
-
-    goToConfigure() {
-      document.location = '#/configure';
-    }
-
-    init() {
-      if (this.hasAccess()) {
-        if (this.selectedSourceId() == null) {
-          this.newSource();
-        } else {
-          this.loading(true);
-          sourceApi.getSource(this.selectedSourceId())
-            .then((source) => {
-              this.selectedSource(new Source(source));
-              this.dirtyFlag(new ohdsiUtil.dirtyFlag(this.selectedSource()));
-              this.loading(false);
-            });
-        }
+      try {
+        this.loading(true);
+        await sourceApi.deleteSource(this.selectedSourceId());
+        const appStatus = await sourceApi.initSourcesConfig();
+        sharedState.appInitializationStatus(appStatus);
+        const roles = await roleService.getList();
+        this.model.roles(roles); // TODO: Move roles to shared state
+        this.goToConfigure();
+      } catch (err) {
+        console.error(err);
+      } finally {
+        this.loading(false);
       }
     }
 
+    goToConfigure() {
+      commonUtils.routeTo('/configure');
+    }
+
+    onRouterParamsChanged(params = {}) {
+      const selectedSourceId = parseInt(this.selectedSourceId());
+			if (this.isNew() && !this.dirtyFlag().isDirty()) {
+				this.newSource();
+			} else if (selectedSourceId > 0 && selectedSourceId !== (this.selectedSource() && this.selectedSource().sourceId())) {
+				this.onSourceSelected();
+			}
+    }
+
+    async onSourceSelected() {
+      if (this.hasAccess()) {
+        try {
+          this.loading(true);
+          const source = await sourceApi.getSource(this.selectedSourceId());
+          this.selectedSource(new Source(source));
+          this.dirtyFlag(new ohdsiUtil.dirtyFlag(this.selectedSource()));
+        } catch (e) {
+          console.error(e);
+          alert(`An error occurred while attempting to get a source with id=${this.selectedSourceId()}.`);
+          commonUtils.routeTo('/configure');
+        } finally {
+          this.loading(false);
+        }
+      }
+    }
   }
 
   return commonUtils.build('source-manager', SourceManager, view);

--- a/js/pages/configuration/sources/source-manager.js
+++ b/js/pages/configuration/sources/source-manager.js
@@ -349,11 +349,11 @@ define([
 
     onRouterParamsChanged(params = {}) {
       const selectedSourceId = parseInt(this.selectedSourceId());
-			if (this.isNew() && !this.dirtyFlag().isDirty()) {
-				this.newSource();
-			} else if (selectedSourceId > 0 && selectedSourceId !== (this.selectedSource() && this.selectedSource().sourceId())) {
-				this.onSourceSelected();
-			}
+      if (this.isNew() && !this.dirtyFlag().isDirty()) {
+        this.newSource();
+      } else if (selectedSourceId > 0 && selectedSourceId !== (this.selectedSource() && this.selectedSource().sourceId())) {
+        this.onSourceSelected();
+      }
     }
 
     async onSourceSelected() {

--- a/js/services/SourceAPI.js
+++ b/js/services/SourceAPI.js
@@ -29,7 +29,7 @@ define(function (require, exports) {
       formData.append("source", new Blob([JSON.stringify(source)],{type: "application/json"}));
 
       lscache.remove(getCacheKey());
-      if (sourceKey) {
+      if (sourceKey && parseInt(sourceKey) !== 0) {
         return httpService.doPut(config.api.url + 'source/' + (sourceKey), formData);
       } else {
         return httpService.doPost(config.api.url + 'source/' + (''), formData);


### PR DESCRIPTION
As part of #1565 
+ Fixes #1975 

- Moved code related to Configuration Sources from Model.js to sharedState
- Changed Configuration page to extend from Page and not from Component
- Added ability to come back to opened source and see status (unsaved/opened) in sidebar menu
- New source has id of 0 instead of 'new' in url to be consistent with other new entities
- Added alert message when loading of source failed(ex. when trying to load source with unexisted id)
- Removed blinking of form when deleting source and going back to configure page.