### PR TITLE
Removed component-specific stuff from Model.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
 
 			<div class="app__menu">
 				<!-- ko foreach: router.pages -->
-				<a data-bind="attr: {href: navUrl()}, css: $parent.classes({ element: 'menu-item', modifiers: $parent.activePage() === $data.title ? 'selected' : '', extra: statusCss() })">
+				<a data-bind="attr: {href: navUrl()}, css: $parent.classes({ element: 'menu-item', modifiers: $parent.router.activeRoute().title === $data.title ? 'selected' : '', extra: statusCss() })">
 					<i data-bind="css: $parent.classes({ element: 'menu-icon', extra: `fa fa-fw fa-${icon}`})" aria-hidden="true"></i>
 					<span data-bind="text: $data.title, css: $parent.classes('menu-title')"></span>
 				</a>
@@ -105,7 +105,7 @@
 
 				<!-- ko ifnot: EventBus.errorMsg() -->
 				<div data-bind="if: currentViewAccessible" class="flexed">
-					<div id="currentComponent" class="flexed" data-bind='component: {name: $data.currentView, params: { routerParams: routerParams, model: $data } }'></div>
+					<div id="currentComponent" class="flexed" data-bind='component: {name: $data.currentView, params: { router: $data.router } }'></div>
 				</div>
 				<!-- /ko -->
 

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
 		<div id="wrapperMainWindow" style="display:none;" data-bind="visible:initializationComplete(), css: classes({ element: 'main-window'})">
 			<div id="wrapperMainWindowContainer">
 				<user-bar params="{model: $data}"></user-bar>
-				<div data-bind="if: !currentViewAccessible()">
+				<div data-bind="if: !router.currentViewAccessible()">
 					<div style="width:100px;margin-left:auto;margin-right:auto;">
 						<svg width="100" height="100" viewBox="0 -200 400 400">
 							<g id="rings">
@@ -85,7 +85,7 @@
 					</div>
 				</div>
 				<!-- ko if: $data.currentCohortDefinition() || $data.currentConceptSet() -->
-				<!-- ko if: $data.currentCohortDefinition() != null && $data.currentView() !='cohort-definition-manager' && $data.currentView() != 'loading' -->
+				<!-- ko if: $data.currentCohortDefinition() != null && $data.router.currentView() !='cohort-definition-manager' && $data.router.currentView() != 'loading' -->
 				<div class="breadcrumb-container">
 					<i class="fa fa-arrow-left"></i>
 					<a data-bind="attr: { href: '#/cohortdefinition/' + $data.currentCohortDefinition().id()}, text: $data.currentCohortDefinition().name"></a>
@@ -95,7 +95,7 @@
 					<!-- /ko -->
 				</div>
 				<!-- /ko -->
-				<!-- ko if: $data.currentConceptSet() && $data.currentConceptSetSource() == 'repository' && $data.currentView() != 'conceptset-manager' -->
+				<!-- ko if: $data.currentConceptSet() && $data.currentConceptSetSource() == 'repository' && $data.router.currentView() != 'conceptset-manager' -->
 				<div class="breadcrumb-container">
 					<i class="fa fa-arrow-left"></i>
 					<a data-bind="attr: { href: '#/conceptset/' + $data.currentConceptSet().id + '/details'}, text:$data.currentConceptSet().name"></a>
@@ -104,8 +104,8 @@
 				<!-- /ko -->
 
 				<!-- ko ifnot: EventBus.errorMsg() -->
-				<div data-bind="if: currentViewAccessible" class="flexed">
-					<div id="currentComponent" class="flexed" data-bind='component: {name: $data.currentView, params: { router: $data.router } }'></div>
+				<div data-bind="if: $data.router.currentViewAccessible" class="flexed">
+					<div id="currentComponent" class="flexed" data-bind='component: {name: $data.router.currentView, params: { router: $data.router, model: $data } }'></div>
 				</div>
 				<!-- /ko -->
 

--- a/js/Application.js
+++ b/js/Application.js
@@ -3,6 +3,7 @@ define(
 		'knockout',
 		'services/http',
 		'services/AuthAPI',
+		'services/role',
 		'appConfig',
 		'lscache',
 		'atlas-state',
@@ -17,6 +18,7 @@ define(
 		ko,
 		httpService,
 		authApi,
+		roleService,
 		config,
 		lscache,
 		sharedState,
@@ -34,6 +36,23 @@ define(
 				this.densityPriority = 0;
 				this.pageModel = model;
 				this.router = router;
+				this.pageTitle = ko.pureComputed(() => {
+					let pageTitle = "ATLAS";
+					switch (sharedState.currentView()) {
+						case 'loading':
+							pageTitle = pageTitle + ": Loading";
+							break;
+						default:
+							pageTitle = `${pageTitle}: ${this.router.activeRoute().title}`;
+							break;
+					}
+
+					if (this.pageModel.hasUnsavedChanges()) {
+						pageTitle = "*" + pageTitle + " (unsaved)";
+					}
+
+					return pageTitle;
+				})
 			}
 
 			/**
@@ -49,6 +68,7 @@ define(
 						// provide to a view access to both model and the router via this.router
 						...this.pageModel,
 						...this,
+						currentView: sharedState.currentView,
 					}, document.getElementsByTagName('html')[0]);
 					httpService.setUnauthorizedHandler(() => authApi.resetAuthParams());
 					httpService.setUserTokenGetter(() => authApi.getAuthorizationHeader());
@@ -61,7 +81,6 @@ define(
 
 					}
 					authApi.isAuthenticated.subscribe(executionService.checkExecutionEngineStatus);
-					this.router.setCurrentViewHandler(this.pageModel.handleViewChange);
 					this.router.setModelGetter(() => this.pageModel);
 					this.attachGlobalEventListeners();
 					await executionService.checkExecutionEngineStatus(authApi.isAuthenticated());
@@ -79,7 +98,7 @@ define(
 			synchronize() {
 				const promise = Promise.all([
 					this.initServiceInformation(),
-					this.pageModel.updateRoles(),
+					roleService.updateRoles(),
 				]);
 				promise.then(() => {
 					this.router.run();

--- a/js/Application.js
+++ b/js/Application.js
@@ -38,7 +38,7 @@ define(
 				this.router = router;
 				this.pageTitle = ko.pureComputed(() => {
 					let pageTitle = "ATLAS";
-					switch (sharedState.currentView()) {
+					switch (this.router.currentView()) {
 						case 'loading':
 							pageTitle = pageTitle + ": Loading";
 							break;
@@ -68,7 +68,6 @@ define(
 						// provide to a view access to both model and the router via this.router
 						...this.pageModel,
 						...this,
-						currentView: sharedState.currentView,
 					}, document.getElementsByTagName('html')[0]);
 					httpService.setUnauthorizedHandler(() => authApi.resetAuthParams());
 					httpService.setUserTokenGetter(() => authApi.getAuthorizationHeader());

--- a/js/Application.js
+++ b/js/Application.js
@@ -40,7 +40,7 @@ define(
 					let pageTitle = "ATLAS";
 					switch (this.router.currentView()) {
 						case 'loading':
-							pageTitle = pageTitle + ": Loading";
+							pageTitle = `${pageTitle}: Loading`;
 							break;
 						default:
 							pageTitle = `${pageTitle}: ${this.router.activeRoute().title}`;
@@ -48,7 +48,7 @@ define(
 					}
 
 					if (this.pageModel.hasUnsavedChanges()) {
-						pageTitle = "*" + pageTitle + " (unsaved)";
+						pageTitle = `*${pageTitle} (unsaved)`;
 					}
 
 					return pageTitle;

--- a/js/Model.js
+++ b/js/Model.js
@@ -47,18 +47,12 @@ define(
 				super();
 				const bemHelper = new BemHelper('app');
 				this.classes = bemHelper.run.bind(bemHelper);
-				this.activePage = ko.observable();
 				this.componentParams = ko.observable({});
-				this.routerParams = ko.observable();
-				this.pendingSearch = ko.observable(false);
-				this.supportURL = config.supportUrl;
-				this.targetSupportURL = config.supportUrl.startsWith("#") ? "_this" : "_blank";
 				this.relatedConceptsColumns = constants.getRelatedConceptsColumns(sharedState);
 				this.relatedConceptsOptions = constants.relatedConceptsOptions;
 				this.relatedSourcecodesOptions = constants.relatedSourcecodesOptions;
 				this.relatedSourcecodesColumns = constants.getRelatedSourcecodesColumns(sharedState, this);
 				this.enableRecordCounts = ko.observable(true);
-				this.loading = ko.observable(false);
 				this.loadingIncluded = ko.observable(false);
 				this.loadingSourcecodes = ko.observable(false);
 				this.loadingEvidence = ko.observable(false);
@@ -87,7 +81,6 @@ define(
 				this.cohortDefinitionSourceInfo = ko.observableArray();
 				this.recentSearch = ko.observableArray(null);
 				this.recentConcept = ko.observableArray(null);
-				this.currentView = ko.observable('loading');
 				this.conceptSetInclusionIdentifiers = ko.observableArray();
 				this.currentConceptSetExpressionJson = ko.observable();
 				this.currentConceptIdentifierList = ko.observable();
@@ -136,12 +129,7 @@ define(
 				this.metarchy = {};
 				this.conceptSetInclusionCount = ko.observable(0);
 				this.sourcecodeInclusionCount = ko.observable(0);
-				this.users = ko.observableArray();
-				this.permissions = ko.observableArray();
 				this.currentConceptSet = ko.observable();
-				this.currentRoleId = ko.observable();
-				this.roles = sharedState.roles;
-				this.signInOpened = authApi.signInOpened;
 
 				this.plpCss = ko.pureComputed(() => {
 					if (this.currentPatientLevelPrediction())
@@ -249,25 +237,6 @@ define(
 					return url;
 				});
 
-				this.irStatusCss = ko.pureComputed(() => {
-					if (this.currentIRAnalysis())
-						return this.currentIRAnalysisDirtyFlag()
-							.isDirty() ? "unsaved" : "open";
-				});
-				this.irAnalysisURL = ko.pureComputed(() => {
-					var url = "#/iranalysis";
-					if (this.currentIRAnalysis())
-						url = url + "/" + (this.currentIRAnalysis()
-							.id() || 'new');
-					return url;
-				});
-
-				this.irStatusCss = ko.pureComputed(() => {
-					if (this.currentIRAnalysis())
-						return this.currentIRAnalysisDirtyFlag()
-							.isDirty() ? "unsaved" : "open";
-				});
-
 				this.hasUnsavedChanges = ko.pureComputed(() => {
 					return ((
 						this.currentCohortDefinitionDirtyFlag()
@@ -287,19 +256,19 @@ define(
 					return sharedState.appInitializationStatus() != constants.applicationStatuses.initializing;
 				});
 				this.currentViewAccessible = ko.pureComputed(() => {
-					return this.currentView && (
+					return sharedState.currentView && (
 						sharedState.appInitializationStatus() !== constants.applicationStatuses.failed
 						&& (sharedState.appInitializationStatus() !== constants.applicationStatuses.noSourcesAvailable
-						|| ['ohdsi-configuration', 'source-manager'].includes(this.currentView())
+						|| ['ohdsi-configuration', 'source-manager'].includes(sharedState.currentView())
 					));
 				});
 
-				this.currentView.subscribe(() => {
+				sharedState.currentView.subscribe(() => {
 					EventBus.errorMsg(undefined);
 				});
 
 				this.noSourcesAvailable = ko.pureComputed(() => {
-					return sharedState.appInitializationStatus() === constants.applicationStatuses.noSourcesAvailable && this.currentView() !== 'ohdsi-configuration';
+					return sharedState.appInitializationStatus() === constants.applicationStatuses.noSourcesAvailable && sharedState.currentView() !== 'ohdsi-configuration';
 				});
 				this.appInitializationStatus = ko.computed(() => sharedState.appInitializationStatus());
 				this.appInitializationErrorMessage =  ko.computed(() => {
@@ -309,23 +278,7 @@ define(
 						return 'unable to connect to an instance of the webapi.<br/>please contact your administrator to resolve this issue.'
 					}
 				});
-				this.pageTitle = ko.pureComputed(() => {
-					let pageTitle = "ATLAS";
-					switch (this.currentView()) {
-						case 'loading':
-							pageTitle = pageTitle + ": Loading";
-							break;
-						default:
-							pageTitle = `${pageTitle}: ${this.activePage()}`;
-							break;
-					}
 
-					if (this.hasUnsavedChanges()) {
-						pageTitle = "*" + pageTitle + " (unsaved)";
-					}
-
-					return pageTitle;
-				});
 
 				this.renderConceptSetItemSelector = commonUtils.renderConceptSetItemSelector.bind(this);
 				this.renderConceptSelector = commonUtils.renderConceptSelector.bind(this);
@@ -366,16 +319,6 @@ define(
 						}
 					});
 			*/
-			}
-
-			handleViewChange(view, routerParams = false) {
-				if (view !== this.currentView()) {
-					this.currentView('loading');
-				}
-				if (routerParams !== false) {
-					this.routerParams(routerParams);
-				}
-				this.currentView(view);
 			}
 
 			setConceptSetExpressionExportItems() {
@@ -507,7 +450,7 @@ define(
 					// If we continue, then clear the loaded concept set
 					this.clearConceptSet();
 				}
-				this.currentView('loading');
+				sharedState.currentView('loading');
 
 				if (cohortDefinitionId == '0') {
 					this.currentCohortDefinition(new CohortDefinition({ id: '0', name: 'New Cohort Definition' }));
@@ -611,7 +554,7 @@ define(
 						} catch(er) {
 							this.handleVocabularyDataSourceFailure('Loading cohort definition failed');
 					}
-					this.currentView(viewToShow);
+					sharedState.currentView(viewToShow);
 
 			}
 
@@ -686,7 +629,7 @@ define(
 					this.handleViewChange(viewToShow, { conceptSetId, mode });
 					return;
 				}
-				this.currentView('loading');
+				sharedState.currentView('loading');
 				try {
 					const conceptset = await conceptSetService.loadConceptSet(conceptSetId);
 					const data = await conceptSetService.loadConceptSetExpression(conceptSetId);
@@ -739,7 +682,7 @@ define(
 							name: conceptSet.name,
 							id: conceptSet.id
 						});
-						this.currentView(viewToShow);
+						sharedState.currentView(viewToShow);
 						this.resolveConceptSetExpression()
 							.then(() => {
 								this.currentConceptSetMode(mode);
@@ -844,26 +787,6 @@ define(
 						break;
 				}
 			}
-
-			updateRoles() {
-				if (authApi.isPermittedReadRoles()){
-					if (!config.userAuthenticationEnabled)
-							return true;
-
-					console.info('Updating roles');
-					if (!authApi.isAuthenticated()) {
-						console.warn('Roles are not updated');
-						return Promise.resolve();
-					}
-
-					return roleService.getList()
-						.then((roles) => {
-							console.info('Roles updated');
-							this.roles(roles);
-						});
-				}
-			}
-
 		}
 	}
 );

--- a/js/components/ac-unauthenticated.html
+++ b/js/components/ac-unauthenticated.html
@@ -1,5 +1,5 @@
 <div>
     <p>
-        This feature is protected. Please, <a href="" data-bind="click: function () { $root.signInOpened(true) }">log in</a>.
+        This feature is protected. Please, <a href="" data-bind="click: function () { $component.signInOpened(true) }">log in</a>.
     </p>
 </div>

--- a/js/components/ac-unauthenticated.js
+++ b/js/components/ac-unauthenticated.js
@@ -1,6 +1,7 @@
-define(['knockout', 'text!./unauthenticated.html', 'appConfig'], function (ko, view, appConfig) {
+define(['knockout', 'text!./unauthenticated.html', 'appConfig', 'services/AuthAPI'], function (ko, view, appConfig, authApi) {
     function unauthenticated(params) {
         var self = this;
+        this.signInOpened = authApi.signInOpened;
     }
 
     var component = {

--- a/js/components/atlas-state.js
+++ b/js/components/atlas-state.js
@@ -6,7 +6,10 @@ define(['knockout', 'lscache', 'services/job/jobDetail', 'assets/ohdsi.util', 'c
 	state.jobListing = ko.observableArray();
 	state.priorityScope = ko.observable('session');
 	state.roles = ko.observableArray();
+	state.users = ko.observableArray();
 	state.sources = ko.observableArray([]);
+	state.currentView = ko.observable('loading');
+	state.loading = ko.observable(false);
 
 	state.sourceKeyOfVocabUrl = ko.computed(() => {
 		return state.vocabularyUrl() ? state.vocabularyUrl().replace(/\/$/, '').split('/').pop() : null;

--- a/js/components/terms-and-conditions/terms-and-conditions.js
+++ b/js/components/terms-and-conditions/terms-and-conditions.js
@@ -6,6 +6,7 @@ define([
   'utils/CommonUtils',
   'services/MomentAPI',
   'services/AuthAPI',
+  'pages/Router',
   'moment',
   'appConfig',
   'less!./terms-and-conditions.less',
@@ -18,6 +19,7 @@ define([
   commonUtils,
   momentApi,
   authApi,
+  router,
   momentjs,
   appConfig,
 ) {
@@ -37,11 +39,11 @@ define([
       this.content = appConfig.termsAndConditions.content;
       this.isAccepted = ko.observable(true);
 
-      params.model.currentView.subscribe(() => {
+      router.currentView.subscribe(() => {
         this.isAccepted(this.checkAcceptance());
       });
     }
-    
+
     checkAcceptance() {
       const acceptanceDate = localStorage.getItem('terms-and-conditions-acceptance-date');
       if (acceptanceDate !== null) {

--- a/js/components/user-bar.js
+++ b/js/components/user-bar.js
@@ -35,8 +35,8 @@ define([
 			this.authLogin = authApi.subject;
 			this.fullName = authApi.fullName;
 			this.pollId = null;
-			this.loading = params.model.loading;
-			this.signInOpened = params.model.signInOpened;
+			this.loading = state.loading;
+			this.signInOpened = authApi.signInOpened;
 			this.jobListing = state.jobListing;
 			this.sortedJobListing = ko.computed(() => lodash.sortBy(this.jobListing(), el => -1 * el.executionId));
 			this.lastViewedTime=null;

--- a/js/main.js
+++ b/js/main.js
@@ -12,7 +12,7 @@ require(["./settings"], (settings) => {
 			...settings.localRefs,
 		},
 //		urlArgs: bustCache,
-	});	
+	});
 	require([
 		'bootstrap',
 		'ko.sortable',
@@ -40,10 +40,10 @@ require(["./settings"], (settings) => {
 				Model,
 				appConfig,
 				constants,
-				Router,
+				router,
 				sharedState,
 			) => {
-				const app = new Application(new Model(), new Router());
+				const app = new Application(new Model(), router);
 
 				app.bootstrap()
 					.then(() => app.checkOAuthError())

--- a/js/pages/Page.js
+++ b/js/pages/Page.js
@@ -22,14 +22,14 @@ define([
   class Page extends Component {
     constructor(params) {
       super(params);
-			this.subscriptions = [];
-      this.routerParams = params.routerParams();
-      this.activePage = params.model.activePage();
-      this.subscriptions.push(params.routerParams.subscribe(newParams => {
+      this.subscriptions = [];
+      this.routerParams = params.router.routerParams();
+      this.activeRoute = params.router.activeRoute();
+      this.subscriptions.push(params.router.routerParams.subscribe(newParams => {
         const np = Object.entries(newParams === undefined ? {} : newParams);
         const op = Object.entries(this.routerParams === undefined ? {} : this.routerParams);
         const changedParams = _.differenceWith(np, op, detectChanges);
-        if (changedParams.length === 0 || this.activePage !== params.model.activePage()) {
+        if (changedParams.length === 0 || this.activeRoute.title !== params.router.activeRoute().title) {
           return;
         }
         const changedParamsMap = changedParams.reduce((map, value) => { map[value[0]] = value[1]; return map; }, {});

--- a/js/pages/Router.js
+++ b/js/pages/Router.js
@@ -29,16 +29,15 @@ define(
         this.pages = Object.values(pages);
         this.routerParams = ko.observable();
         this.currentViewAccessible = ko.pureComputed(() => {
-          // return true;
           return this.currentView && (
-						sharedState.appInitializationStatus() !== constants.applicationStatuses.failed
-						&& (sharedState.appInitializationStatus() !== constants.applicationStatuses.noSourcesAvailable
-						|| ['ohdsi-configuration', 'source-manager'].includes(this.currentView())
-					));
+            sharedState.appInitializationStatus() !== constants.applicationStatuses.failed
+            && (sharedState.appInitializationStatus() !== constants.applicationStatuses.noSourcesAvailable
+            || ['ohdsi-configuration', 'source-manager'].includes(this.currentView())
+          ));
         });
         this.currentView.subscribe(() => {
-					EventBus.errorMsg(undefined);
-				});
+          EventBus.errorMsg(undefined);
+        });
       }
 
       run() {

--- a/js/pages/Router.js
+++ b/js/pages/Router.js
@@ -24,7 +24,6 @@ define(
       constructor() {
         this.activeRoute = ko.observable({});
         this.currentView = ko.observable('loading');
-        console.log(constants)
         this.onLoginSubscription;
         this.getModel = () => { throw new Exception('Model getter is not set'); };
         this.pages = Object.values(pages);

--- a/js/pages/characterizations/routes.js
+++ b/js/pages/characterizations/routes.js
@@ -9,7 +9,6 @@ define(
 		function routes(appModel, router) {
 
             const characterizationViewEdit = new AuthorizedRoute((id, section, subId) => {
-                appModel.activePage(this.title);
                 router.setCurrentView('characterization-view-edit', {
                     characterizationId: id,
                     section: section || 'design',
@@ -19,7 +18,6 @@ define(
 
 			return {
 				'cc/characterizations': new AuthorizedRoute(() => {
-					appModel.activePage(this.title);
 					require(['./components/characterizations/characterizations-list'], function () {
 						router.setCurrentView('characterizations-list');
 					});
@@ -28,13 +26,11 @@ define(
 				'cc/characterizations/:id:/:section:': characterizationViewEdit,
 				'cc/characterizations/:id:/:section:/:subId:': characterizationViewEdit, // for executions
 				'cc/feature-analyses': new AuthorizedRoute(() => {
-					appModel.activePage(this.title);
 					require(['./components/feature-analyses/feature-analyses-list'], function () {
 						router.setCurrentView('feature-analyses-list');
 					});
 				}),
 				'cc/feature-analyses/:id:': new AuthorizedRoute((id) => {
-					appModel.activePage(this.title);
 					require(['./components/feature-analyses/feature-analysis-view-edit'], function () {
 						router.setCurrentView('feature-analysis-view-edit', { id });
 					});

--- a/js/pages/cohort-definitions/cohort-definition-manager.html
+++ b/js/pages/cohort-definitions/cohort-definition-manager.html
@@ -1,4 +1,4 @@
-<div data-bind="if: $root.currentCohortDefinition() && $root.currentView() == 'cohort-definition-manager'" class="flexed">
+<div data-bind="if: $root.currentCohortDefinition() && $root.router.currentView() == 'cohort-definition-manager'" class="flexed">
 	<heading-title params="name: cohortDefinitionCaption(), icon: 'users', theme: 'dark'"></heading-title>
 
 	<access-denied params="isAuthenticated: isAuthenticated, isPermitted: hasAccess"></access-denied>
@@ -107,7 +107,7 @@
 					</li>
 				</ul>
 
-				<div data-bind="if: $root.currentView() != 'loading' && $component.conceptSetTabMode() === cohortConst.conceptSetTabModes.details">
+				<div data-bind="if: $root.router.currentView() != 'loading' && $component.conceptSetTabMode() === cohortConst.conceptSetTabModes.details">
 					<div class="paddedWrapper">
 						<div class="heading">
 							Name:
@@ -124,7 +124,7 @@
 					</div>
 				</div>
 
-				<div class="loading" data-bind="if:$root.currentView() === 'loading' || $root.loadingSourcecodes() || $root.loadingIncluded">loading</div>
+				<div class="loading" data-bind="if:$root.router.currentView() === 'loading' || $root.loadingSourcecodes() || $root.loadingIncluded">loading</div>
 
 				<div data-bind="visible: $component.conceptSetTabMode() === cohortConst.conceptSetTabModes.included && !$root.loadingIncluded()">
 					<faceted-datatable params="{columns: $component.includedConceptsColumns, options: $component.includedConceptsOptions, reference: $root.includedConcepts, drawCallback: $component.includedDrawCallback, rowCallback: $root.contextSensitiveLinkColor}"></faceted-datatable>
@@ -545,7 +545,7 @@
 						</div>
 					</div>
 				</div>
-				<loading params="status:'loading'" data-bind="visible:$root.currentView() == 'loading' || $root.loadingReport()">
+				<loading params="status:'loading'" data-bind="visible:$root.router.currentView() == 'loading' || $root.loadingReport()">
 				</loading>
 				<report-manager data-bind="visible:$component.reportingState()=='report_active' " params="{model: model, showSelectionArea: false} "></report-manager>
 			</div>

--- a/js/pages/cohort-definitions/routes.js
+++ b/js/pages/cohort-definitions/routes.js
@@ -2,9 +2,8 @@ define(
 	(require, factory) => {
     const { AuthorizedRoute } = require('pages/Route');
     function routes(appModel, router) {
-      return {        
+      return {
         '/cohortdefinitions': new AuthorizedRoute(() => {
-          appModel.activePage(this.title);
           require([
             './cohort-definitions',
             './cohort-definition-manager',
@@ -14,7 +13,6 @@ define(
           });
         }),
         '/cohortdefinition/:cohortDefinitionId:/?((\w|.)*)': new AuthorizedRoute((cohortDefinitionId, path = 'definition') => {
-          appModel.activePage(this.title);
           require([
            'components/cohortbuilder/CohortDefinition',
             'components/atlas.cohort-editor',
@@ -41,7 +39,6 @@ define(
           });
         }),
         '/cohortdefinition/:cohortDefinitionId/conceptset/:conceptSetId/:mode:': new AuthorizedRoute((cohortDefinitionId, conceptSetId, mode) => {
-          appModel.activePage(this.title);
           require([
            'components/cohortbuilder/CohortDefinition',
             'components/atlas.cohort-editor',
@@ -58,7 +55,6 @@ define(
           });
         }),
         '/reports': new AuthorizedRoute(() => {
-          appModel.activePage(this.title);
           require([
             './components/reporting/cost-utilization/report-manager',
             './cohort-definition-manager',

--- a/js/pages/concept-sets/routes.js
+++ b/js/pages/concept-sets/routes.js
@@ -3,7 +3,6 @@ define(
     const { AuthorizedRoute } = require('pages/Route');
     function routes(appModel, router) {
       const detailsRoute = new AuthorizedRoute((conceptSetId, mode = 'conceptset-expression') => {
-        appModel.activePage(this.title);
         require(['./conceptset-manager', 'components/cohort-definition-browser', 'conceptset-list-modal'], function () {
           appModel.loadConceptSet(conceptSetId, 'conceptset-manager', 'repository', mode);
         });
@@ -13,13 +12,11 @@ define(
         '/conceptset/:conceptSetId': detailsRoute,
         '/conceptset/:conceptSetId/:mode': detailsRoute,
         '/conceptsets': new AuthorizedRoute(() => {
-          appModel.activePage(this.title);
           require(['./conceptset-browser'], function () {
             router.setCurrentView('conceptset-browser');
           });
         }),
         '/concept/:conceptId:': new AuthorizedRoute((conceptId) => {
-          appModel.activePage(this.title);
           require(['./concept-manager'], function () {
             appModel.currentConceptId(conceptId);
             router.setCurrentView('concept-manager', { conceptId });

--- a/js/pages/configuration/roles/roles.js
+++ b/js/pages/configuration/roles/roles.js
@@ -5,6 +5,7 @@ define([
     'utils/AutoBind',
     'utils/CommonUtils',
     'services/AuthAPI',
+    'services/role',
     'atlas-state',
     'databindings',
     'components/ac-access-denied',
@@ -16,6 +17,7 @@ define([
     AutoBind,
     commonUtils,
     authApi,
+    roleService,
     sharedState
 ) {
     class Roles extends AutoBind(Page) {
@@ -24,7 +26,7 @@ define([
             this.model = params.model;
             this.roles = ko.observable([]);
             this.loading = ko.observable();
-    
+
             this.isAuthenticated = authApi.isAuthenticated;
             this.canRead = ko.pureComputed(() => { return this.isAuthenticated() && authApi.isPermittedReadRoles(); });
             this.canCreate = ko.pureComputed(() => { return this.isAuthenticated() && authApi.isPermittedCreateRole(); });
@@ -33,13 +35,13 @@ define([
         onPageCreated() {
             if (this.canRead()) {
                 this.loading(true);
-                this.model.updateRoles().then(() => {
+                roleService.updateRoles().then(() => {
                     this.loading(false);
-                    this.roles(this.model.roles());
+                    this.roles(sharedState.roles());
                 });
-            }            
+            }
         }
-        
+
         selectRole(data) {
             commonUtils.routeTo('/role/' + data.id);
         }

--- a/js/pages/configuration/routes.js
+++ b/js/pages/configuration/routes.js
@@ -4,38 +4,31 @@ define(
     const { AuthorizedRoute } = require('pages/Route');
     function routes(appModel, router) {
       const JobViewEdit = new AuthorizedRoute((id, section) => {
-				appModel.activePage(this.title);
 				require(['./users-import/job-view-edit'], function () {
 					router.setCurrentView('import-job-view-edit', {
 						jobId: id,
 						section: section,
 					});
 				});
-			});
+			}, this.title);
       return {
         '/configure': new AuthorizedRoute(() => {
-          appModel.activePage(this.title);
           require(['./configuration', './sources/source-manager'], function () {
             router.setCurrentView('ohdsi-configuration');
           });
         }),
         '/roles': new AuthorizedRoute(() => {
-          appModel.activePage(this.title);
           require(['./roles/roles'], function () {
             router.setCurrentView('roles');
           });
         }),
         '/role/:id': new AuthorizedRoute((id) => {
-          appModel.activePage(this.title);
           require(['./roles/role-details'], function () {
-            appModel.currentRoleId(id);
-            router.setCurrentView('role-details', {
-              roleId: id,
-            });
+            const roleId = parseInt(id);
+            router.setCurrentView('role-details', { roleId });
           });
         }),
         'import' : new AuthorizedRoute(() => {
-          appModel.activePage(this.title);
           require(['./users-import/browser'], function () {
             router.setCurrentView('user-import-browser');
 					});
@@ -43,19 +36,17 @@ define(
         'import/job/:id:' : JobViewEdit,
         'import/job/:id:/:section:': JobViewEdit,
         'import/wizard': new AuthorizedRoute(() => {
-          appModel.activePage(this.title);
           require(['./users-import/users-import'], function() {
             router.setCurrentView('users-import');
           });
         }),
         'import/roles': new AuthorizedRoute(() => {
-          appModel.activePage(this.title);
           require(['./roles/role-import'], function() {
             router.setCurrentView('role-import');
           });
         }),
-        '/source/:id': new AuthorizedRoute((sourceId) => {
-          appModel.activePage(this.title);
+        '/source/:id': new AuthorizedRoute((id) => {
+          const sourceId = parseInt(id);
           require(['./sources/source-manager'], function () {
             atlasState.ConfigurationSource.selectedId(sourceId);
             router.setCurrentView('source-manager', { sourceId });

--- a/js/pages/configuration/users-import/job-view-edit.js
+++ b/js/pages/configuration/users-import/job-view-edit.js
@@ -8,6 +8,7 @@ define([
 	'assets/ohdsi.util',
 	'./services/JobService',
 	'services/User',
+	'services/role',
 	'./services/PermissionService',
 	'./const',
 	'moment',
@@ -26,6 +27,7 @@ define([
 	ohdsiUtil,
 	jobService,
 	userService,
+	roleService,
 	permissionService,
 	Const,
 	moment,
@@ -55,7 +57,6 @@ define([
 			super(params);
 
 			this.model = params.model;
-			this.updateRoles = params.model.updateRoles;
 			this.roles = sharedState.roles;
 			this.jobId = ko.observable();
 			this.loading = ko.observable();
@@ -108,7 +109,7 @@ define([
 				weekdays: this.weekdays,
 				roleGroups: this.roleGroups,
 			});
-			this.updateRoles()
+			roleService.updateRoles()
 				.then(roles => {
 					const mapping = this.roles().filter(role => !role.defaultImported).map(role => (
 						{

--- a/js/pages/configuration/users-import/users-import.js
+++ b/js/pages/configuration/users-import/users-import.js
@@ -4,6 +4,7 @@ define(['knockout',
 		'atlas-state',
 		'services/AuthAPI',
 		'services/User',
+		'services/role',
 		'utils/AutoBind',
 		'components/Component',
 		'utils/CommonUtils',
@@ -20,12 +21,13 @@ define(['knockout',
 		'components/heading'
 	],
 	function (
-		ko, 
-		view, 
+		ko,
+		view,
 		config,
 		sharedState,
-		authApi, 
+		authApi,
 		userService,
+		roleService,
 		AutoBind,
 		Component,
 		commonUtils,
@@ -69,7 +71,6 @@ define(['knockout',
 				// form inputs
 				this.importProvider = ko.observable(Const.PROVIDERS.ACTIVE_DIRECTORY);
 				this.model = params.model;
-				this.updateRoles = params.model.updateRoles;
 				this.roles = sharedState.roles;
 				this.rolesMapping = ko.observableArray();
 				this.selectedRole = ko.observable();
@@ -166,7 +167,7 @@ define(['knockout',
 					}));
 				userService.importUsers(users, this.importProvider()).finally(() => {
 						this.loading(false);
-						userService.getUsers().then(data => this.model.users(data));
+						userService.getUsers().then(data => sharedState.users(data));
 				});
 				return true;
 			}
@@ -301,7 +302,7 @@ define(['knockout',
 				userService.getAuthenticationProviders().then(providers => {
 					this.providers(providers);
 				}).finally(() => this.loading(false));
-				this.updateRoles().then(() => {
+				roleService.updateRoles().then(() => {
 					const mapping = this.roles().filter(role => !role.defaultImported).map(role => (
 						{
 							...role,

--- a/js/pages/data-sources/routes.js
+++ b/js/pages/data-sources/routes.js
@@ -4,13 +4,11 @@ define(
     function routes(appModel, router) {
       return {
         '/datasources': new AuthorizedRoute(() => {
-          appModel.activePage(this.title);
           require(['./data-sources'], function () {
             router.setCurrentView('data-sources');
           });
         }),
         '/datasources/:sourceKey/:reportName': new AuthorizedRoute((sourceKey, reportName) => {
-          appModel.activePage(this.title);
           require(['./data-sources'], function () {
             router.setCurrentView('data-sources', {
               reportName: reportName ? decodeURIComponent(reportName) : reportName,

--- a/js/pages/estimation/cca-manager.js
+++ b/js/pages/estimation/cca-manager.js
@@ -1,6 +1,6 @@
 define([
-	'knockout', 
-	'text!./cca-manager.html',	
+	'knockout',
+	'text!./cca-manager.html',
     'pages/Page',
 	'utils/CommonUtils',
 	'assets/ohdsi.util',
@@ -8,6 +8,7 @@ define([
 	'./const',
 	'const',
 	'atlas-state',
+	'pages/Router',
 	'./PermissionService',
 	'services/Estimation',
     './inputTypes/EstimationAnalysis',
@@ -25,8 +26,8 @@ define([
 	'less!./cca-manager.less',
 	'databindings',
 ], function (
-	ko, 
-	view, 
+	ko,
+	view,
 	Page,
 	commonUtils,
 	ohdsiUtil,
@@ -34,6 +35,7 @@ define([
 	constants,
 	globalConstants,
 	sharedState,
+	router,
 	PermissionService,
 	EstimationService,
 	EstimationAnalysis,
@@ -67,7 +69,7 @@ define([
 			this.isExporting = ko.observable(false);
 			this.loadingMessage = ko.observable(this.defaultLoadingMessage);
 			this.packageName = ko.observable().extend({alphaNumeric: null});
-			this.selectedTabKey = ko.observable(params.routerParams().section);
+			this.selectedTabKey = ko.observable(router.routerParams().section);
 			this.isSaving = ko.observable(false);
 			this.isCopying = ko.observable(false);
 			this.isDeleting = ko.observable(false);
@@ -190,21 +192,21 @@ define([
 				comp.outcomes().map(o => this.addCohortToEstimation(specification, o));
 
 				if (comp.negativeControlOutcomesConceptSet() !== null && comp.negativeControlOutcomesConceptSet().id > 0) {
-					this.addConceptSetToEstimation(specification, ko.toJS(comp.negativeControlOutcomesConceptSet), 
-						constants.conceptSetCrossReference.negativeControlOutcomes.targetName, 
-						index, 
+					this.addConceptSetToEstimation(specification, ko.toJS(comp.negativeControlOutcomesConceptSet),
+						constants.conceptSetCrossReference.negativeControlOutcomes.targetName,
+						index,
 						constants.conceptSetCrossReference.negativeControlOutcomes.propertyName);
 				}
 				if (comp.includedCovariateConceptSet() !== null && comp.includedCovariateConceptSet().id > 0) {
-					this.addConceptSetToEstimation(specification, ko.toJS(comp.includedCovariateConceptSet), 
+					this.addConceptSetToEstimation(specification, ko.toJS(comp.includedCovariateConceptSet),
 						constants.conceptSetCrossReference.targetComparatorOutcome.targetName,
-						index, 
+						index,
 						constants.conceptSetCrossReference.targetComparatorOutcome.propertyName.includedCovariateConcepts);
 				}
 				if (comp.excludedCovariateConceptSet() !== null && comp.excludedCovariateConceptSet().id > 0) {
-					this.addConceptSetToEstimation(specification, ko.toJS(comp.excludedCovariateConceptSet), 
+					this.addConceptSetToEstimation(specification, ko.toJS(comp.excludedCovariateConceptSet),
 						constants.conceptSetCrossReference.targetComparatorOutcome.targetName,
-						index, 
+						index,
 						constants.conceptSetCrossReference.targetComparatorOutcome.propertyName.excludedCovariateConcepts);
 				}
 			});
@@ -214,15 +216,15 @@ define([
 
 				const covarSettings = a.getDbCohortMethodDataArgs.covariateSettings;
 				if (covarSettings.includedCovariateConceptSet !== null && covarSettings.includedCovariateConceptSet.id > 0) {
-					this.addConceptSetToEstimation(specification, covarSettings.includedCovariateConceptSet, 
-						constants.conceptSetCrossReference.analysisCovariateSettings.targetName, 
-						index, 
+					this.addConceptSetToEstimation(specification, covarSettings.includedCovariateConceptSet,
+						constants.conceptSetCrossReference.analysisCovariateSettings.targetName,
+						index,
 						constants.conceptSetCrossReference.analysisCovariateSettings.propertyName.includedCovariateConcepts);
 				}
 				if (covarSettings.excludedCovariateConceptSet !== null && covarSettings.excludedCovariateConceptSet.id > 0) {
-					this.addConceptSetToEstimation(specification, covarSettings.excludedCovariateConceptSet, 
+					this.addConceptSetToEstimation(specification, covarSettings.excludedCovariateConceptSet,
 						constants.conceptSetCrossReference.analysisCovariateSettings.targetName,
-						index, 
+						index,
 						constants.conceptSetCrossReference.analysisCovariateSettings.propertyName.excludedCovariateConcepts);
 				}
 
@@ -230,17 +232,17 @@ define([
 				specification.estimationAnalysisSettings.analysisSpecification.cohortMethodAnalysisList[index].getDbCohortMethodDataArgs.covariateSettings = ko.toJS(new CovariateSettings(covarSettings));
 			});
 			let pcsaCovarSettings = specification.positiveControlSynthesisArgs.covariateSettings;
-			if (pcsaCovarSettings != null) {				
+			if (pcsaCovarSettings != null) {
 				if (pcsaCovarSettings.includedCovariateConceptSet !== null && pcsaCovarSettings.includedCovariateConceptSet.id > 0) {
-					this.addConceptSetToEstimation(specification, pcsaCovarSettings.includedCovariateConceptSet, 
-						constants.conceptSetCrossReference.positiveControlCovariateSettings.targetName, 
-						index, 
+					this.addConceptSetToEstimation(specification, pcsaCovarSettings.includedCovariateConceptSet,
+						constants.conceptSetCrossReference.positiveControlCovariateSettings.targetName,
+						index,
 						constants.conceptSetCrossReference.positiveControlCovariateSettings.targetName.includedCovariateConcepts);
 				}
 				if (pcsaCovarSettings.excludedCovariateConceptSet !== null && pcsaCovarSettings.excludedCovariateConceptSet.id > 0) {
-					this.addConceptSetToEstimation(specification, pcsaCovarSettings.excludedCovariateConceptSet, 
-						constants.conceptSetCrossReference.positiveControlCovariateSettings.targetName, 
-						index, 
+					this.addConceptSetToEstimation(specification, pcsaCovarSettings.excludedCovariateConceptSet,
+						constants.conceptSetCrossReference.positiveControlCovariateSettings.targetName,
+						index,
 						constants.conceptSetCrossReference.positiveControlCovariateSettings.targetName.includedCovariateConcepts);
 				}
 
@@ -311,7 +313,7 @@ define([
 				let target = null;
 				let comparator = null;
 				const outcomes = [];
-		
+
 				if (tco.targetId() !== null) {
 					const tCohortDefinitionList = cohortDefinitions.filter(d => d.id() === tco.targetId());
 					if (tCohortDefinitionList.length > 0) {
@@ -338,7 +340,7 @@ define([
 				});
 
 				const comp = new Comparison({
-					target: target, 
+					target: target,
 					comparator: comparator,
 					outcomes: outcomes,
 				});
@@ -442,7 +444,7 @@ define([
 					targetIndex: targetIndex,
 					propertyName: propertyName
 				})
-			);				
+			);
 		}
 	}
 

--- a/js/pages/estimation/routes.js
+++ b/js/pages/estimation/routes.js
@@ -4,11 +4,10 @@ define((require, factory) => {
     function routes(appModel, router) {
 
       const ccaViewEdit = new AuthorizedRoute((estimationId, section) => {
-        appModel.activePage(this.title);
         require(['./cca-manager'], function () {
           atlasState.estimationAnalysis.selectedId(estimationId);
           router.setCurrentView('cca-manager', {
-            id: estimationId, 
+            id: estimationId,
             section: section || 'specification',
           });
         });
@@ -16,7 +15,6 @@ define((require, factory) => {
 
       return {
         '/estimation': new AuthorizedRoute(() => {
-          appModel.activePage(this.title);
           require(['./estimation-browser'], function () {
             router.setCurrentView('estimation-browser');
           });

--- a/js/pages/feedback/routes.js
+++ b/js/pages/feedback/routes.js
@@ -2,9 +2,8 @@ define(
   (require, factory) => {
     const { Route } = require('pages/Route');
     function routes(appModel, router) {
-      return {        
+      return {
         '/feedback': new Route(() => {
-          appModel.activePage(this.title);
           require(['feedback'], function () {
             router.setCurrentView('feedback');
           });

--- a/js/pages/home/routes.js
+++ b/js/pages/home/routes.js
@@ -2,21 +2,18 @@ define(
 	(require, factory) => {
     const { Route } = require('pages/Route');
     const authApi = require('services/AuthAPI');
-    
+
     function routes(appModel, router) {
       return {
         '/': new Route(() => {
-          appModel.activePage(this.title);
           document.location = "#/home";
         }),
         '/home': new Route(() => {
-          appModel.activePage(this.title);
           require(['./home'], function () {
             router.setCurrentView('home');
           });
         }),
         '/welcome/:token': new Route((token) => {
-          appModel.activePage(this.title);
           require(['welcome'], function () {
             authApi.token(token);
             document.location = "#/welcome";

--- a/js/pages/incidence-rates/const.js
+++ b/js/pages/incidence-rates/const.js
@@ -12,6 +12,13 @@ define(
         COMPLETE: 'COMPLETE',
     };
 
+    const tabs = {
+      DEFINITION: 'definition',
+      CONCEPT_SETS: 'conceptsets',
+      GENERATION: 'generation',
+      UTILITIES: 'utilities',
+    };
+
     const disabledReasons = {
       DIRTY: 'Save changes to generate',
       ACCESS_DENIED: 'Access denied',
@@ -26,6 +33,7 @@ define(
       status,
       isInProgress,
       disabledReasons,
+      tabs,
     };
   }
 );

--- a/js/pages/incidence-rates/ir-manager.html
+++ b/js/pages/incidence-rates/ir-manager.html
@@ -23,29 +23,30 @@
 		</div>
 
 		<ul class="nav nav-tabs">
-			<li role="presentation" data-bind="css: { active: $component.activeTab() == 'definition' }, click: function() { $component.activeTab('definition') };">
+			<li role="presentation" data-bind="css: { active: $component.activeTab() == tabs.DEFINITION }, click: function() { $component.activeTab(tabs.DEFINITION) };">
 				<a>Definition</a>
 			</li>
 
-			<li role="presentation" data-bind="css: { active: $component.activeTab() == 'conceptsets' }, click: function() { $component.activeTab('conceptsets') };">
+			<li role="presentation" data-bind="css: { active: $component.activeTab() == tabs.CONCEPT_SETS }, click: function() { $component.activeTab(tabs.CONCEPT_SETS) };">
 				<a>Concept Sets</a>
 			</li>
 
-			<li role="presentation" data-bind="css: { active: $component.activeTab() == 'generation' }, click: function() { $component.activeTab('generation') };">
+			<li role="presentation" data-bind="css: { active: $component.activeTab() == tabs.GENERATION }, click: function() { $component.activeTab(tabs.GENERATION) };">
 				<a>Generation</a>
 			</li>
 
-            <li role="presentation" data-bind="css: { active: $component.activeTab() == 'utilities' }, click: function() { $component.activeTab('utilities') };"><a>Utilities</a>
+            <li role="presentation" data-bind="css: { active: $component.activeTab() == tabs.UTILITIES }, click: function() { $component.activeTab(tabs.UTILITIES) };">
+				<a>Utilities</a>
             </li>
 
 		</ul>
 		<div class="tab-content">
-			<div role="tabpanel" data-bind="css: { active: $component.activeTab() == 'definition' }" class="tab-pane">
+			<div role="tabpanel" data-bind="css: { active: $component.activeTab() == tabs.DEFINITION }" class="tab-pane">
 				<div data-bind="eventListener: { event: 'click', selector: '.conceptset_import', callback: handleConceptSetImport}">
 					<ir-analysis-editor params="analysis: selectedAnalysis().expression, analysisCohorts: analysisCohorts, isEditable: isEditable"></ir-analysis-editor>
 				</div>
 			</div>
-			<div role="tabpanel" data-bind="css: { active: $component.activeTab() == 'conceptsets' }" class="tab-pane">
+			<div role="tabpanel" data-bind="css: { active: $component.activeTab() == tabs.CONCEPT_SETS }" class="tab-pane">
 				<div style="padding-bottom: 10px;" class="pull-right">
 					<!-- Button is hidden since function exportConceptSetsCSV not yet implemented -->
 					<button type="button" style="display: none" class="btn btn-sm btn-success pull-right" data-bind="click:function() { exportConceptSetsCSV(); }, css: {'disabled': dirtyFlag().isDirty, 'btn-success': !dirtyFlag().isDirty()}"><i class="fa fa-download" aria-hidden="true"></i> Export All Concept Sets To CSV</button>
@@ -54,7 +55,7 @@
 					<concept-set-builder params="conceptSets: ConceptSets, ref: $parent.conceptSetEditor"></concept-set-builder>
 				<!-- /ko -->
 			</div>
-			<div role="tabpanel" data-bind="css: { active: $component.activeTab() == 'generation' },
+			<div role="tabpanel" data-bind="css: { active: $component.activeTab() == tabs.GENERATION },
 																			eventListener: [
 																				{ event: 'click', selector: 'button.removeResult', callback: removeResult},
 																				{ event: 'click', selector: 'button.exportAnalysisCSV', callback: exportAnalysisCSV},
@@ -65,7 +66,7 @@
 					<ir-analysis-results params="sources: $component.sources, analysisCohorts: analysisCohorts, execute: execute, cancelExecution: cancelExecution, stoppingSources: stoppingSources, loadingSummary: loadingSummary"></ir-analysis-results>
 				</div>
 			</div>
-            <div role="tabpanel" data-bind="css: { active: $component.activeTab() == 'utilities' }" class="tab-pane">
+            <div role="tabpanel" data-bind="css: { active: $component.activeTab() == tabs.UTILITIES }" class="tab-pane">
 				<div class="paddedWrapper">
                     <ul class="nav nav-pills">
                         <li role="presentation" data-bind="css: {active: $component.expressionMode() == 'import' }, click: function() {$component.expressionMode('import') };"><a>Import</a></li>

--- a/js/pages/incidence-rates/ir-manager.html
+++ b/js/pages/incidence-rates/ir-manager.html
@@ -23,19 +23,19 @@
 		</div>
 
 		<ul class="nav nav-tabs">
-			<li role="presentation" data-bind="css: { active: $component.activeTab() == tabs.DEFINITION }, click: function() { $component.activeTab(tabs.DEFINITION) };">
+			<li role="presentation" data-bind="css: { active: $component.activeTab() == tabs.DEFINITION }, click: function() { $component.selectTab(tabs.DEFINITION) };">
 				<a>Definition</a>
 			</li>
 
-			<li role="presentation" data-bind="css: { active: $component.activeTab() == tabs.CONCEPT_SETS }, click: function() { $component.activeTab(tabs.CONCEPT_SETS) };">
+			<li role="presentation" data-bind="css: { active: $component.activeTab() == tabs.CONCEPT_SETS }, click: function() { $component.selectTab(tabs.CONCEPT_SETS) };">
 				<a>Concept Sets</a>
 			</li>
 
-			<li role="presentation" data-bind="css: { active: $component.activeTab() == tabs.GENERATION }, click: function() { $component.activeTab(tabs.GENERATION) };">
+			<li role="presentation" data-bind="css: { active: $component.activeTab() == tabs.GENERATION }, click: function() { $component.selectTab(tabs.GENERATION) };">
 				<a>Generation</a>
 			</li>
 
-            <li role="presentation" data-bind="css: { active: $component.activeTab() == tabs.UTILITIES }, click: function() { $component.activeTab(tabs.UTILITIES) };">
+            <li role="presentation" data-bind="css: { active: $component.activeTab() == tabs.UTILITIES }, click: function() { $component.selectTab(tabs.UTILITIES) };">
 				<a>Utilities</a>
             </li>
 

--- a/js/pages/incidence-rates/ir-manager.js
+++ b/js/pages/incidence-rates/ir-manager.js
@@ -59,11 +59,12 @@ define([
 			this.loading = ko.observable(false);
 			this.loadingInfo = ko.observable();
 			this.loadingSummary = ko.observableArray();
+			this.constants = constants;
+			this.tabs = constants.tabs;
 			this.selectedAnalysis = sharedState.IRAnalysis.current;
 			this.selectedAnalysisId = sharedState.IRAnalysis.selectedId;
 			this.dirtyFlag = sharedState.IRAnalysis.dirtyFlag;
 			this.exporting = ko.observable();
-			this.constants = constants;
 			this.defaultName = globalConstants.newEntityNames.incidenceRate;
 			this.canCreate = ko.pureComputed(() => {
 				return !config.userAuthenticationEnabled
@@ -106,7 +107,7 @@ define([
 			});
 
 			this.isRunning = ko.observable(false);
-			this.activeTab = ko.observable(params.activeTab || 'definition');
+			this.activeTab = ko.observable(params.activeTab || this.tabs.DEFINITION);
 			this.conceptSetEditor = ko.observable(); // stores a reference to the concept set editor
 			this.sources = ko.observableArray();
 			this.stoppingSources = ko.observable({});
@@ -281,11 +282,16 @@ define([
 		}
 
 		onRouterParamsChanged(params = {}) {
-			const { analysisId } = params;
+			const { analysisId, activeTab } = params;
 			if (analysisId && parseInt(analysisId) !== (this.selectedAnalysis() && this.selectedAnalysis().id())) {
 				this.onAnalysisSelected();
 			} else if (this.selectedAnalysis() && this.selectedAnalysis().id()) {
 				this.startPolling();
+			}
+			if (activeTab) {
+				if (Object.values(this.constants.tabs).includes(activeTab)) {
+					this.activeTab(activeTab);
+				}
 			}
 		}
 
@@ -308,7 +314,7 @@ define([
 			if (result.action === 'add') {
 				var newConceptSet = this.conceptSetEditor().createConceptSet();
 				this.criteriaContext() && this.criteriaContext().conceptSetId(newConceptSet.id);
-				this.activeTab('conceptsets');
+				this.activeTab(this.tabs.CONCEPT_SETS);
 			}
 			this.criteriaContext(null);
 		}
@@ -435,7 +441,7 @@ define([
 			this.loading(true);
 			try {
 				this.refreshDefs();
-				this.activeTab('definition');
+				this.activeTab(this.tabs.DEFINITION);
 				this.close();
 				commonUtils.routeTo(constants.apiPaths.analysis(res.id));
 			} catch (e) {

--- a/js/pages/incidence-rates/ir-manager.js
+++ b/js/pages/incidence-rates/ir-manager.js
@@ -281,17 +281,21 @@ define([
 			});
 		}
 
+		selectTab(tab) {
+			commonUtils.routeTo(`${this.constants.apiPaths.analysis(this.selectedAnalysisId())}/${tab}`);
+		}
+
 		onRouterParamsChanged(params = {}) {
 			const { analysisId, activeTab } = params;
-			if (analysisId && parseInt(analysisId) !== (this.selectedAnalysis() && this.selectedAnalysis().id())) {
-				this.onAnalysisSelected();
-			} else if (this.selectedAnalysis() && this.selectedAnalysis().id()) {
-				this.startPolling();
-			}
 			if (activeTab) {
 				if (Object.values(this.constants.tabs).includes(activeTab)) {
 					this.activeTab(activeTab);
 				}
+			}
+			if (analysisId && parseInt(analysisId) !== (this.selectedAnalysis() && this.selectedAnalysis().id())) {
+				this.onAnalysisSelected();
+			} else if (this.selectedAnalysis() && this.selectedAnalysis().id() && !this.pollId) {
+				this.startPolling();
 			}
 		}
 

--- a/js/pages/incidence-rates/routes.js
+++ b/js/pages/incidence-rates/routes.js
@@ -3,24 +3,21 @@ define(
     const { AuthorizedRoute } = require('pages/Route');
 		const atlasState = require('atlas-state');
     function routes(appModel, router) {
-      return {        
-        '/iranalysis': new AuthorizedRoute(() => {
-          appModel.activePage(this.title);
-          require(['./ir-browser'], function () {
+      return {
+        '/iranalysis': new AuthorizedRoute(() =>  {
+          require(['./ir-browser'], () => {
             router.setCurrentView('ir-browser');
           });
         }),
-        '/iranalysis/new': new AuthorizedRoute((analysisId) => {
-          appModel.activePage(this.title);
-          require(['./ir-manager'], function () {
+        '/iranalysis/new': new AuthorizedRoute(analysisId => {
+          require(['./ir-manager'], () => {
             atlasState.IRAnalysis.selectedId(null);
             router.setCurrentView('ir-manager', {});
           });
         }),
         '/iranalysis/:analysisId:/?((\w|.)*)': new AuthorizedRoute((analysisId, path) => {
-          appModel.activePage(this.title);
           path = path.split("/");
-          var activeTab = null;
+          let activeTab = null;
           if (path.length > 0 && path[0] !== "") {
             activeTab = path[0];
           }

--- a/js/pages/incidence-rates/routes.js
+++ b/js/pages/incidence-rates/routes.js
@@ -23,7 +23,7 @@ define(
           }
           require(['./ir-manager'], function () {
             atlasState.IRAnalysis.selectedId(+analysisId);
-            router.setCurrentView('ir-manager', { analysisId });
+            router.setCurrentView('ir-manager', { analysisId, activeTab });
           });
         }),
       };

--- a/js/pages/jobs/job-manager.html
+++ b/js/pages/jobs/job-manager.html
@@ -5,7 +5,7 @@
 		<div class="clear"></div>
 
 		<table width="100%" class="conceptTable stripe compact hover" cellspacing="0" data-bind="dataTable:{
-			data: $root.jobs(),
+			data: jobs(),
 			options: {
 						dom: 'Blfiprt',
 						language: {
@@ -20,7 +20,7 @@
 						autoWidth: false,
 						ordering: true,
 						order: [[ 0, 'desc' ]],
-						columns: $root.columns()
+						columns: columns()
 				}
 		}"></table>
 	</div>

--- a/js/pages/jobs/job-manager.js
+++ b/js/pages/jobs/job-manager.js
@@ -26,8 +26,8 @@ define([
 	class JobManager extends AutoBind(Page) {
 		constructor(params) {
 			super(params);
-			this.model = params.model;
-			this.model.columns = ko.observableArray([
+			this.jobs = ko.observableArray([]);
+			this.columns = ko.observableArray([
 				{title: 'ExecutionId', data: 'executionId'},
 				{title: 'Job Name', data: 'jobParameters.jobName'},
 				{title: 'Status', data: 'status'},
@@ -35,7 +35,8 @@ define([
 				{title: 'End Date', data: 'endDate'}
 			]);
 			if (config.userAuthenticationEnabled) {
-				this.model.columns.splice(3, 0, {title: 'Author', data: 'jobParameters.jobAuthor', 'defaultContent': ''});
+				// Add 'Author' column after 'Status' column
+				this.columns.splice(3, 0, {title: 'Author', data: 'jobParameters.jobAuthor', 'defaultContent': ''});
 			}
 			this.isAuthenticated = authApi.isAuthenticated;
 			this.canReadJobs = ko.pureComputed(() => {
@@ -48,10 +49,8 @@ define([
 		}
 
 		async updateJobs() {
-			this.model.jobs([]);
-
 			const jobs = await jobsService.getList();
-			this.model.jobs(jobs.map((job) => {
+			this.jobs(jobs.map((job) => {
 				const { startDate = null, endDate = null } = job;
 				job.startDate = startDate ? momentApi.formatDateTime(new Date(startDate)) : '-';
 				job.endDate = endDate && (endDate > startDate) ? momentApi.formatDateTime(new Date(endDate)) : '-';

--- a/js/pages/jobs/routes.js
+++ b/js/pages/jobs/routes.js
@@ -2,9 +2,8 @@ define(
 	(require, factory) => {
     const { AuthorizedRoute } = require('pages/Route');
     function routes(appModel, router) {
-      return {        
+      return {
         '/jobs': new AuthorizedRoute(() => {
-          appModel.activePage(this.title);
           require(['pages/jobs/job-manager'], function () {
             router.setCurrentView('job-manager');
           });

--- a/js/pages/pathways/routes.js
+++ b/js/pages/pathways/routes.js
@@ -8,7 +8,6 @@ define((require, factory) => {
 	function routes(appModel, router) {
 
 		const pathwaysManager = new AuthorizedRoute((id, section, subId) => {
-			appModel.activePage(this.title);
 			require(['./components/manager'], function () {
 				router.setCurrentView('pathways-manager', {
 					analysisId: id,
@@ -19,7 +18,6 @@ define((require, factory) => {
 		});
 
 		const pathwaysBrowser = new AuthorizedRoute(() => {
-			appModel.activePage(this.title);
 			require(['./components/browser'], function () {
 				router.setCurrentView('pathways-browser');
 			});

--- a/js/pages/prediction/prediction-manager.js
+++ b/js/pages/prediction/prediction-manager.js
@@ -1,7 +1,8 @@
 define([
-	'knockout', 
-	'text!./prediction-manager.html',	
+	'knockout',
+	'text!./prediction-manager.html',
 	'pages/Page',
+	'pages/Router',
 	'utils/CommonUtils',
 	'assets/ohdsi.util',
     'appConfig',
@@ -29,9 +30,10 @@ define([
 	'less!./prediction-manager.less',
 	'databindings',
 ], function (
-	ko, 
-	view, 
+	ko,
+	view,
 	Page,
+	router,
 	commonUtils,
 	ohdsiUtil,
 	config,
@@ -56,7 +58,7 @@ define([
 			sharedState.predictionAnalysis.analysisPath = constants.paths.analysis;
 
 			this.selectTab = this.selectTab.bind(this);
-			this.selectedTabKey = ko.observable(params.routerParams().section);
+			this.selectedTabKey = ko.observable(router.routerParams().section);
 
 			this.isAuthenticated = authAPI.isAuthenticated;
 			this.hasAccess = authAPI.isPermittedReadPlps;
@@ -140,7 +142,7 @@ define([
 				this.loading(false);
 			}
 		}
-		
+
         onRouterParamsChanged({ id, section }) {
 			if (id !== undefined && id !== parseInt(this.selectedAnalysisId())) {
 				if (section !== undefined) {
@@ -301,7 +303,7 @@ define([
 		onAnalysisSelected() {
 			this.loading(true);
 			PredictionService.getPrediction(this.selectedAnalysisId()).then((analysis) => {
-				this.loadAnalysisFromServer(analysis);				
+				this.loadAnalysisFromServer(analysis);
 				this.loading(false);
 			});
 		}
@@ -319,7 +321,7 @@ define([
 			this.patientLevelPredictionAnalysis().description(header.description);
 			this.packageName(header.packageName);
 			this.setUserInterfaceDependencies();
-			this.setAnalysisSettingsLists();	
+			this.setAnalysisSettingsLists();
 			this.fullSpecification(null);
 			this.resetDirtyFlag();
 		}
@@ -358,7 +360,7 @@ define([
 					if (xref.propertyName === constants.conceptSetCrossReference.covariateSettings.propertyName.excludedCovariateConcepts) {
 						this.patientLevelPredictionAnalysis().covariateSettings()[xref.targetIndex].excludedCovariateConceptSet(selectedConceptSet);
 					}
-				}				
+				}
 			});
 		}
 

--- a/js/pages/prediction/routes.js
+++ b/js/pages/prediction/routes.js
@@ -5,29 +5,26 @@ define(
     function routes(appModel, router) {
 
       const predictionViewEdit = new AuthorizedRoute((analysisId, section) => {
-        appModel.activePage(this.title);
         require([
-          './prediction-manager', 
+          './prediction-manager',
           './components/editors/evaluation-settings-editor',
-          './components/editors/execution-settings-editor', 
-          './components/editors/model-settings-editor', 
+          './components/editors/execution-settings-editor',
+          './components/editors/model-settings-editor',
           './components/editors/population-settings-editor',
           './components/editors/prediction-covariate-settings-editor',
         ], function() {
           atlasState.predictionAnalysis.selectedId(analysisId);
-          appModel.currentView('prediction-manager');
           router.setCurrentView('prediction-manager', {
-            id: analysisId, 
+            id: analysisId,
             section: section || 'specification',
           });
         });
       });
 
-      return {        
+      return {
         '/prediction': new AuthorizedRoute(() => {
-          appModel.activePage(this.title);
           require(['./prediction-browser'], function() {
-            appModel.currentView('prediction-browser');
+            router.setCurrentView('prediction-browser');
           })
         }),
         '/prediction/:analysisId:': predictionViewEdit,

--- a/js/pages/profiles/profile-manager.js
+++ b/js/pages/profiles/profile-manager.js
@@ -14,6 +14,7 @@ define([
 		'pages/Page',
 		'utils/AutoBind',
 		'utils/CommonUtils',
+		'pages/Router',
 		'./const',
 		'lodash',
 		'crossfilter',
@@ -41,6 +42,7 @@ define([
 		Page,
 		AutoBind,
 		commonUtils,
+		router,
 		constants,
 		_,
 		crossfilter,
@@ -64,11 +66,11 @@ define([
 				this.filterHighlightsText = ko.observable();
 				this.loadingStatus = ko.observable('loading');
 
-				this.sourceKey = ko.observable(params.routerParams().sourceKey);
-				this.personId = ko.observable(params.routerParams().personId);
+				this.sourceKey = ko.observable(router.routerParams().sourceKey);
+				this.personId = ko.observable(router.routerParams().personId);
 				this.personRecords = ko.observableArray();
 
-				this.cohortDefinitionId = ko.observable(params.routerParams().cohortDefinitionId);
+				this.cohortDefinitionId = ko.observable(router.routerParams().cohortDefinitionId);
 				this.currentCohortDefinition = ko.observable(null);
 				// if a cohort definition id has been specified, see if it is
 				// already loaded into the page model. If not, load it from the

--- a/js/pages/profiles/routes.js
+++ b/js/pages/profiles/routes.js
@@ -2,9 +2,8 @@ define(
 	(require, factory) => {
     const { AuthorizedRoute } = require('pages/Route');
     function routes(appModel, router) {
-      return {        
+      return {
         '/profiles/?((\w|.)*)': new AuthorizedRoute((path) => {
-          appModel.activePage(this.title);
           require(['./profile-manager', 'components/cohort-definition-browser'], function () {
             path = path.split("/");
             const params = {};

--- a/js/pages/vocabulary/routes.js
+++ b/js/pages/vocabulary/routes.js
@@ -6,7 +6,6 @@ define(
 		function routes(appModel, router) {
 
             const search = new AuthorizedRoute((query) => {
-                appModel.activePage(this.title);
                 require(['./vocabulary'], function (search) {
                     const view = 'vocabulary';
                     let params = {
@@ -16,7 +15,7 @@ define(
                 });
             });
 
-			return {        
+			return {
 				'/search/:query:': search,
 				'/search': search,
 			};

--- a/js/services/role.js
+++ b/js/services/role.js
@@ -2,6 +2,9 @@ define(function(require, exports) {
 
   var constants = require('const');
   const httpService = require('services/http');
+  const sharedState = require('atlas-state');
+  const config = require('appConfig');
+  const authApi = require('services/AuthAPI');
 
   return class RolesService {
     static getList() {
@@ -49,6 +52,28 @@ define(function(require, exports) {
 
     static delete(id) {
       return httpService.doDelete(constants.apiPaths.role(id));
+    }
+
+    static async updateRoles() {
+      if (authApi.isPermittedReadRoles()){
+        if (!config.userAuthenticationEnabled)
+            return true;
+
+        console.info('Updating roles');
+        if (!authApi.isAuthenticated()) {
+          console.warn('Roles are not updated');
+          return Promise.resolve();
+        }
+
+        try {
+          const roles = await this.getList();
+          console.info('Roles updated');
+          sharedState.roles(roles);
+          return roles;
+        } catch (err) {
+          console.error(err);
+        }
+      }
     }
   }
 });


### PR DESCRIPTION
Fixes #1565 
- Removed some dead code from Model.js
- Moved updateRoles to RoleService and updated all components to use this service
- Removed setting handler for router from model and moved routerParams, activePage, etc to router.
- Moved currentView, currentViewAccessible to Router.js
- Moved loading observable and users list to sharedState
- Removed setting activePage in routes.js in pages
- Moved pageTitle to Application.js
- Moved jobs from model.js to jobs-manager component
- Added tabs handling in IR-manager component