### PR TITLE
[2.7.3] Adjust getCohortDefinition() to handle string expression.

### DIFF
--- a/js/Model.js
+++ b/js/Model.js
@@ -513,7 +513,7 @@ define(
 					this.currentCohortDefinition(new CohortDefinition({ id: '0', name: 'New Cohort Definition' }));
 					this.currentCohortDefinitionInfo([]);
 				} else {
-					const { data: cohortDefinition } = await httpService.doGet(config.api.url + 'cohortdefinition/' + cohortDefinitionId);
+					const cohortDefinition = await cohortDefinitionService.getCohortDefinition(cohortDefinitionId);
 					this.currentCohortDefinition(new CohortDefinition(cohortDefinition));
 
 					const { data: generationInfo } = await httpService.doGet(config.api.url + 'cohortdefinition/' + cohortDefinitionId + '/info');

--- a/js/services/CohortDefinition.js
+++ b/js/services/CohortDefinition.js
@@ -64,6 +64,9 @@ define(function (require, exports) {
 				console.log("Error: " + error);
 				authApi.handleAccessDenied(error);
 			}
+		}).then(cohortDef => { 
+			cohortDef.expression = JSON.parse(cohortDef.expression)
+			return cohortDef;
 		});
 		return loadPromise;
 	}


### PR DESCRIPTION
Updates calls to getCohortDefinition endpoint to handle string expression result.

Depends on OHDSI/WebAPI#1262.
