### PR TITLE
Update home page to 2.7.3

### DIFF
--- a/js/pages/home/home.html
+++ b/js/pages/home/home.html
@@ -25,9 +25,9 @@
 	<div class="heading">Release Notes</div>
 	<div class="release-notes">
 		<div class="paddedWrapper">
-			<a href="https://github.com/OHDSI/Atlas/releases" target="_new">ATLAS Version 2.7.3 (Release Candidate) Release Notes</a>
+			<a href="https://github.com/OHDSI/Atlas/releases" target="_new">ATLAS Version 2.7.3 Release Notes</a>
 			<br/>
-			<a href="https://github.com/OHDSI/WebAPI/releases" target="_new">WebAPI Version 2.7.3 (Release Candidate) Release Notes</a>
+			<a href="https://github.com/OHDSI/WebAPI/releases" target="_new">WebAPI Version 2.7.3 Release Notes</a>
 		</div>
 
 		<div class="paddedWrapper">

--- a/js/pages/home/home.js
+++ b/js/pages/home/home.js
@@ -31,7 +31,7 @@ define([
 		}
 
 		async onPageCreated() {
-			const { data } = await httpService.doGet("https://api.github.com/repos/OHDSI/Atlas/issues?state=closed&milestone=26");
+			const { data } = await httpService.doGet("https://api.github.com/repos/OHDSI/Atlas/issues?state=closed&milestone=27");
 			this.github_status(data);
 		}
 


### PR DESCRIPTION
Updating the homepage to remove the "Release Candidate" label in order to finalize v2.7.3