### PR TITLE
Implementation of exporting pathway analysis data.

### DIFF
--- a/js/components/Chart.js
+++ b/js/components/Chart.js
@@ -4,17 +4,22 @@ define([
 	'utils/AutoBind',
 	'utils/ChartUtils',
   'const',
+	'utils/BemHelper',	
   'components/empty-state',
+	'less!./charts/chart.less'
 ], function (
   ko,
   Component,
 	AutoBind,
 	ChartUtils,
   constants,
+	BemHelper
 ) {
   class Chart extends AutoBind(Component) {
     constructor(params, container) {
       super(params);
+			const bemHelper = new BemHelper('Chart');
+      this.chartClasses = bemHelper.run.bind(bemHelper);
       this.renderer = null; // atlascharts
       this.rawData = ko.observable();
       this.format = {};

--- a/js/components/Chart.js
+++ b/js/components/Chart.js
@@ -1,15 +1,19 @@
 define([
   'knockout',
   'components/Component',
+	'utils/AutoBind',
+	'utils/ChartUtils',
   'const',
   'components/empty-state',
 ], function (
   ko,
   Component,
+	AutoBind,
+	ChartUtils,
   constants,
 ) {
-  class Chart extends Component {
-    constructor(params) {
+  class Chart extends AutoBind(Component) {
+    constructor(params, container) {
       super(params);
       this.renderer = null; // atlascharts
       this.rawData = ko.observable();
@@ -19,6 +23,8 @@ define([
       this.data = ko.computed(() => {
         return this.prepareData(this.rawData());
       });
+			this.container = container;
+			this.filename = params.filename || 'untitledChart.png';
     }
 
     prepareData(rawData) {
@@ -29,6 +35,12 @@ define([
       this.minHeight = params.minHeight || constants.minChartHeight;
       this.format = params.format;
     }
+		
+		export() {
+			console.warn('Export not implemented');
+			const svg = this.container.element.querySelector('svg');
+			ChartUtils.downloadAsPng(svg, this.filename || "untitled.png");
+		}
 		
 		dispose() {
 			this.renderer && this.renderer.dispose();

--- a/js/components/Chart.js
+++ b/js/components/Chart.js
@@ -42,7 +42,6 @@ define([
     }
 		
 		export() {
-			console.warn('Export not implemented');
 			const svg = this.container.element.querySelector('svg');
 			ChartUtils.downloadAsPng(svg, this.filename || "untitled.png");
 		}

--- a/js/components/charts/chart.html
+++ b/js/components/charts/chart.html
@@ -1,6 +1,8 @@
 <!-- ko if: data -->
-<div data-bind="chart: { data: data, minHeight: minHeight, format: format, renderer: renderer }"></div>
-<button data-bind="if: $component.filename, click: $component.export">Export</button>
+<div data-bind="css: chartClasses('container')">
+	<button data-bind="css: chartClasses('export-button'),if: $component.filename, click: $component.export">Export</button>
+	<div data-bind="chart: { data: data, minHeight: minHeight, format: format, renderer: renderer }"></div>
+</div>	
 <!-- /ko -->
 <!-- ko ifnot: data -->
   <empty-state></empty-state>

--- a/js/components/charts/chart.html
+++ b/js/components/charts/chart.html
@@ -1,4 +1,7 @@
-<div data-bind="chart: { data: data, minHeight: minHeight, format: format, renderer: renderer }, if: data"></div>
+<!-- ko if: data -->
+<div data-bind="chart: { data: data, minHeight: minHeight, format: format, renderer: renderer }"></div>
+<button data-bind="if: $component.filename, click: $component.export">Export</button>
+<!-- /ko -->
 <!-- ko ifnot: data -->
   <empty-state></empty-state>
 <!-- /ko -->

--- a/js/components/charts/chart.less
+++ b/js/components/charts/chart.less
@@ -1,0 +1,18 @@
+.Chart {
+	
+	&__container {
+		position:relative;
+	}
+	
+	&__export-button {
+		display:none;
+		position:absolute;
+		top:0px;
+		right:0px;		
+	}
+
+	&__container:hover > &__export-button {
+		display:block;
+	}
+	
+}

--- a/js/components/charts/sunburst.js
+++ b/js/components/charts/sunburst.js
@@ -3,8 +3,9 @@ define([
 	'components/Chart',
 	'components/Component',
 	'atlascharts',
-	'text!components/charts/chart.html',
-	'utils/CommonUtils'
+	'text!./chart.html',
+	'utils/CommonUtils',
+	'less!./chart.less'
 ], function (
 	ko,
 	Chart,

--- a/js/components/charts/sunburst.js
+++ b/js/components/charts/sunburst.js
@@ -14,8 +14,8 @@ define([
 	commonUtils
 ) {
 	class Sunburst extends Chart {
-		constructor(params) {
-			super(params);
+		constructor(params, element) {
+			super(params, element);
 			this.renderer = new atlascharts.sunburst();
 		}
 	}

--- a/js/components/nav-pills.html
+++ b/js/components/nav-pills.html
@@ -1,0 +1,5 @@
+	<ul data-bind="css: classes({ element: 'nav', extra: 'nav nav-pills' }), foreach: pills">
+		<li role="presentation" data-bind="css: $component.classes({ element: 'nav-pill', extra: key == $component.selected() ? 'active' : null }), click: $component.onSelect">
+			<a data-bind="text: name"></a>
+		</li>
+	</ul>

--- a/js/components/nav-pills.js
+++ b/js/components/nav-pills.js
@@ -1,0 +1,28 @@
+define([
+	'knockout',
+	'components/Component',
+	'utils/AutoBind',
+	'utils/CommonUtils',
+	'text!./nav-pills.html',	
+	'less!./nav-pills.less',
+], function (
+	ko,
+	Component,
+	AutoBind,
+	commonUtils,
+	view
+) {
+	class NavPills extends AutoBind(Component) {
+		constructor(params) {
+			super();
+			this.selected = params.selected;
+			this.pills = params.pills;
+		}
+		
+		onSelect(pill, event) {
+			this.selected(pill.key);			
+		}
+	}
+	
+	return commonUtils.build('nav-pills', NavPills, view);
+});

--- a/js/components/nav-pills.less
+++ b/js/components/nav-pills.less
@@ -1,0 +1,9 @@
+.pathway-utils {
+	&__nav {
+		margin-top: 1.5rem;
+	}
+
+	&__nav-pill {
+		margin-right: .5rem !important;
+	}
+}

--- a/js/extensions/bindings/dynamicDatatableBinding.js
+++ b/js/extensions/bindings/dynamicDatatableBinding.js
@@ -1,0 +1,13 @@
+define(['jquery', 'knockout', './datatableBinding'], function($,ko) {
+	// re-wire update on binding to rebuild table
+	ko.bindingHandlers.dynamicDataTable = {
+		init: ko.bindingHandlers.dataTable.init,
+		update: (element, valueAccessor) => {
+			var table = $(element).DataTable();
+			table.destroy();
+			$(element).empty();
+			$(element).DataTable(valueAccessor().options);
+			ko.bindingHandlers.dataTable.update(element, valueAccessor);
+		}
+	}
+});

--- a/js/extensions/bindings/main.js
+++ b/js/extensions/bindings/main.js
@@ -9,6 +9,7 @@ define(function (require) {
 	var datePicker = require("./datepickerBinding");
 	var dateTimePicker = require("./dateTimePickerBinding");
 	var dataTable = require("./datatableBinding");
+	var dynamicDataTable = require("./dynamicDatatableBinding");
 	var eventListener = require("./eventListenerBinding");
 	var selectOnFocus = require("./knockout.selectOnFocus");
 	var sortExtender = require("./sortExtender");

--- a/js/pages/pathways/components/tabs/pathway-results.html
+++ b/js/pages/pathways/components/tabs/pathway-results.html
@@ -73,8 +73,9 @@
 					<div class="panel-body">
 						<sunburst data-bind="css: $component.classes('sunburst')"
 								  params="data: () => pathway,
-								minHeight: 300,
-								format: {
+										filename: `${targetCohortName}_sunburst.png`,
+										minHeight: 300,
+										format: {
 										tipClass: $component.classes('d3-tip'),
 										split: $component.splitPathway,
 										colors: $parent.colors,

--- a/js/pages/pathways/components/tabs/pathway-results.html
+++ b/js/pages/pathways/components/tabs/pathway-results.html
@@ -22,9 +22,13 @@
 	<div data-bind="css: classes('filter')">
 		<visualizations-filter-panel params="{ filterList: $component.filterList, live: true }"/>
 	</div>
-
+	
+	<h3 data-bind="css: $component.classes('analysis-name')">Pathways Analysis for <span data-bind="text: pathwaysObserver().title"></span></h3>
+	
+	<nav-pills params="{ pills: $component.pills, selected: $component.mode}"></nav-pills>
+	
 	<!-- ko with: pathwaysObserver -->
-		<h3 data-bind="css: $component.classes('analysis-name')">Pathways Analysis for <span data-bind="text: title"></span></h3>
+	<div data-bind="if: $component.mode() == $component.MODE_VISUALIZATION, css: $component.classes('content')">
 		<div data-bind="if: !eventCodes.length && !cohortPathways.length && !eventCohorts.length">
 			No pathways were found
 		</div>
@@ -119,6 +123,13 @@
 				</div>
 			</div>
 		<!-- /ko -->
+	</div>		
+	<!-- /ko -->
+
+	<!-- ko with: results -->
+	<div data-bind="if: $component.mode() == $component.MODE_TABULAR, css: $component.classes('content')">
+		<pathway-tableview params="{ results: $data, filterList: $component.filterList()[0] }"></pathway-tableview>
+	</div>
 	<!-- /ko -->
 
 	<atlas-modal params="showModal: $component.isExecutionDesignShown, title: 'Design', data: { executionDesign: $component.executionDesign, loadExecutionDesignError: $component.loadExecutionDesignError, classes: $component.classes }">

--- a/js/pages/pathways/components/tabs/pathway-results.js
+++ b/js/pages/pathways/components/tabs/pathway-results.js
@@ -14,6 +14,8 @@ define([
 	'components/visualizations/filter-panel/utils',
 	'components/visualizations/filter-panel/filter-panel',
 	'components/charts/sunburst',
+	'components/nav-pills',
+	'./pathway-tableview',
 	'less!./pathway-results.less'
 ], function(
 	ko,
@@ -33,6 +35,11 @@ define([
 
 	const percentFormat = d3.format(".1%");
 	const numberFormat = d3.format(",");
+	const pills = [
+		{ name: "Visualization", key: "viz"},
+		{ name: "Tabular", key: "table"}
+	];
+	
 
 	class PathwayResults extends AutoBind(Component) {
 
@@ -50,9 +57,15 @@ define([
 			this.isExecutionDesignShown = ko.observable(false);
 			this.executionDesign = ko.observable(null);
 			this.loadExecutionDesignError = ko.observable(false);
-			this.pathwaysObserver = ko.computed(() => this.prepareResultData(this.results(), this.filterList()));
+			this.pathwaysObserver = ko.pureComputed(() => this.prepareResultData(this.results(), this.filterList()));
 
 			this.executionId.subscribe(id => id && this.loadData());
+			
+			this.pills = pills;
+			this.MODE_VISUALIZATION = pills[0].key;
+			this.MODE_TABULAR = pills[1].key;
+			
+			this.mode = ko.observable(pills[0].key);  // default to first pill
 
 			this.loadData();
 		}

--- a/js/pages/pathways/components/tabs/pathway-results.js
+++ b/js/pages/pathways/components/tabs/pathway-results.js
@@ -218,6 +218,7 @@ define([
 				});
 
 				const results = {
+					executionId: this.executionId(),
 					sourceId: source.sourceId,
 					sourceName: source.sourceName,
 					date: execution.endTime,

--- a/js/pages/pathways/components/tabs/pathway-results.less
+++ b/js/pages/pathways/components/tabs/pathway-results.less
@@ -86,9 +86,9 @@
     margin-right: -.75rem;
   }
 
-  &__sunburst > div {
-    width: 550px;
-    height: 550px;
+  &__sunburst > div.Chart__container > div {
+		width:550px;
+		height:550px;
     margin: 0 auto;
   }
 

--- a/js/pages/pathways/components/tabs/pathway-results.less
+++ b/js/pages/pathways/components/tabs/pathway-results.less
@@ -1,5 +1,10 @@
 .pathway-results {
 
+	.nav-pills {
+		margin-top:2rem;
+		margin-bottom: 1rem;
+	}
+	
   &__title {
     align-items: center;
     display: flex;
@@ -64,8 +69,8 @@
   &__analysis-name {
     font-size: 1.6rem;
     font-weight: 600;
-    margin-bottom: 2.5rem;
-    margin-top: 3rem;
+    margin-bottom: 1.5rem;
+    margin-top: 1rem;
   }
 
   &__cohort-name {

--- a/js/pages/pathways/components/tabs/pathway-tableview.html
+++ b/js/pages/pathways/components/tabs/pathway-tableview.html
@@ -1,0 +1,10 @@
+<div style="padding-top: 5px">
+	Maximum Path Length: <select data-bind="options: pathLengthOptions,
+																					 value: pathLength"></select>
+</div>
+<div data-bind="if: reportData">
+	<div data-bind="foreach: reportData().cohorts">
+		<div><span style="font-size: 1.2em; font-weight: bold" data-bind="text: name"></span><button data-bind="css: $component.classes('export-button'), click: $component.exportCohortReport">Export</button></div>
+		<table data-bind="dynamicDataTable: $component.getDataTableBindingData($data)"></table>
+	</div>
+</div>

--- a/js/pages/pathways/components/tabs/pathway-tableview.html
+++ b/js/pages/pathways/components/tabs/pathway-tableview.html
@@ -1,10 +1,33 @@
-<div style="padding-top: 5px">
-	Maximum Path Length: <select data-bind="options: pathLengthOptions,
-																					 value: pathLength"></select>
-</div>
-<div data-bind="if: reportData">
+<div data-bind="css: classes(), if: reportData">
 	<div data-bind="foreach: reportData().cohorts">
-		<div><span style="font-size: 1.2em; font-weight: bold" data-bind="text: name"></span><button data-bind="css: $component.classes('export-button'), click: $component.exportCohortReport">Export</button></div>
-		<table data-bind="dynamicDataTable: $component.getDataTableBindingData($data)"></table>
+		<div data-bind="css: $component.classes('cohort-title')"><span data-bind="text: 'Cohort:  ' + name"></span></div>
+		<hr>
+		<div data-bind="css: $component.classes('table-title')"><span data-bind="text: `Table ${$index()+1}a :` + ' All Pathways'"></span></div>
+		<div> 
+			Maximum Path Length: <select data-bind="options: $component.pathLengthOptions, value: $component.pathLength"></select> 
+			<button data-bind="css: $component.classes('export-button'), click: $component.exportPathwayReport">Export</button>
+		</div>		
+		<table data-bind="dynamicDataTable: $component.getPathwayGroupDatatable($data, $component.pathLength())"></table>
+
+		<div>
+			<span data-bind="css: $component.classes('table-title'), text: `Table ${$index()+1}b :` + ' Event Cohort Counts by Rank'"></span>
+			<button data-bind="css: $component.classes('export-button'), click: $component.exportCountsByRank">Export</button>
+		</div>
+		<table data-bind="dataTable: $component.getEventCohortByRankDatatable($data)"></table>
+		
+		<div>
+			<span data-bind="css: $component.classes('table-title'), text: `Table ${$index()+1}c :` + ' Event Cohort Counts'"></span>
+			<button data-bind="css: $component.classes('export-button'), click: $component.exportEventCohortCounts">Export</button>
+		</div>
+		<table data-bind="dataTable: $component.getEventCohortCountsDatatable($data)"></table>
+		
+		<div>
+			<span data-bind="css: $component.classes('table-title'), text: `Table ${$index()+1}d :` + ' Distinct Event Cohorts'"></span>
+			<button data-bind="css: $component.classes('export-button'), click: $component.exportDistinctEventCohortCounts">Export</button>			
+		</div>
+		<table data-bind="dataTable: $component.getDistinctEventCohortCountsDatatable($data)"></table>
+		
+		<hr>
+		
 	</div>
 </div>

--- a/js/pages/pathways/components/tabs/pathway-tableview.js
+++ b/js/pages/pathways/components/tabs/pathway-tableview.js
@@ -3,6 +3,7 @@ define([
 	'components/Component',
 	'utils/AutoBind',
 	'utils/CommonUtils',
+	'utils/CsvUtils',
 	'text!./pathway-tableview.html',	
 	'less!./pathway-tableview.less',
 	'databindings'
@@ -10,7 +11,8 @@ define([
 	ko,
 	Component,
 	AutoBind,
-	commonUtils,
+	CommonUtils,
+	CsvUtils,
 	view
 ) {
 	
@@ -29,7 +31,7 @@ define([
 	function columnValueBuilder (label, field, formatter) {
 		return {
 			title: label,
-			data: (d) => formatter ? formatter(d[field]) : d[field],
+			data: (d) => formatter ? formatter(d[field]) : d[field] + "", // had to append '' because 0 value was not printing.
 			defaultContent: ''
 		};
 	}
@@ -37,7 +39,7 @@ define([
 	function percentFormat(v) {
 		return `${v.toFixed(2)}%`;
 	}
-
+	
 	class PathwayTableview extends AutoBind(Component) {
 		constructor(params) {
 			super();
@@ -60,7 +62,13 @@ define([
 						name: c.name, 
 						cohortCount: pathwayGroup.targetCohortCount, 
 						pathwayCount: pathwayGroup.totalPathwaysCount,
-						pathways: pathwayGroup.pathways
+						pathways: pathwayGroup.pathways.map(p => ({ // split pathway paths into paths and counts
+							path : p.path.split('-')
+								.map(p => +p)																		
+								.concat(Array(MAX_PATH_LENGTH).fill(null)) // pad end of paths to be at least MAX_PATH_LENGTH
+								.slice(0,MAX_PATH_LENGTH), // limit path to MAX_PATH_LENGTH.
+							personCount: p.personCount
+						}))
 					}
 				}),
 				eventCodes: this.results.data.eventCodes
@@ -74,53 +82,42 @@ define([
 				.join(' + ');
 		}
 		
-		getPathwayGroupData(pathways, pathLength)
+		getPathwayGroupData(pathwayGroup, pathLength)
 		{
-			let data = pathways.map(p => ({
-				path : p.path.split('-',pathLength)
-					.map(p => +p)																		
-					.concat(Array(MAX_PATH_LENGTH).fill(null))
-					.slice(0,pathLength),
-				personCount: p.personCount
-			}));
-
-			let groups = data.reduce((acc,cur) => {
-				const key = JSON.stringify(cur.path);
+			let groups = pathwayGroup.pathways.reduce((acc,cur) => { // reduce pathways into a list of paths with counts
+				const key = JSON.stringify(cur.path.slice(0,pathLength));
 				if (!acc.has(key)) {
-					acc.set(key, cur);
+					acc.set(key, {personCount: cur.personCount, path: cur.path});
 				} else {
 					acc.get(key).personCount += cur.personCount;
 				}
 				return acc;
 			}, new Map()).values();
 
-			return Array.from(groups);
+			const data = Array.from(groups)
+			data.forEach(row => { // add pathway and cohort percents
+				row.pathwayPercent = 100.0 * row.personCount / pathwayGroup.pathwayCount;
+				row.cohortPercent = 100.0 * row.personCount / pathwayGroup.cohortCount;
+			});
+			return data;
 		}	
 		
-		getDataTableBindingData(pathwayGroup) {
-			// 'data' is based on a group-by sum of the specified path lengths
-
+		getPathwayGroupDatatable(pathwayGroup, pathLength) {
 			let pathCols = Array(MAX_PATH_LENGTH)
 				.fill()
 				.map((v,i) => {
 					const col = columnPathBuilder(`Step ${i+1}`, i, this.pathCodeResolver);
-					col.visible = i < this.pathLength();
+					col.visible = i < pathLength;
 					return col;
 				});					
 			let statCols = [columnValueBuilder("Count", "personCount")];
-			let data = this.getPathwayGroupData(pathwayGroup.pathways, this.pathLength());
-
-			// add columns for % of Paths and % of cohort
-			data.forEach(row => {
-				row.pathwayPercent = 100.0 * row.personCount / pathwayGroup.pathwayCount;
-				row.cohortPercent = 100.0 * row.personCount / pathwayGroup.cohortCount;
-			});
+			let data = this.getPathwayGroupData(pathwayGroup, pathLength);
 
 			statCols.push(columnValueBuilder("% with Pathway", "pathwayPercent", percentFormat));
 			statCols.push(columnValueBuilder("% of Cohort", "cohortPercent", percentFormat));
 
 			return {
-				data: data, //data,
+				data: data,
 				options: {
 					autoWidth:true,
 					order: [[pathCols.length, 'desc']],
@@ -130,24 +127,238 @@ define([
 			}
 		}
 		
-		exportCohortReport(d) {
-			const rawData = this.getPathwayGroupData(d.pathways, this.pathLength());
+		exportPathwayReport(pathwayGroup) {
+			const rawData = this.getPathwayGroupData(pathwayGroup, this.pathLength());
 			const csvData = rawData.map(row => {
 				const newRow = {};
+				newRow['sourceName'] = this.results.sourceName;
+				newRow['targetId'] = pathwayGroup.id;
+				newRow['targetname'] = pathwayGroup.name;
+				newRow['cohortCount'] = pathwayGroup.cohortCount;
+				newRow['pathwayCount'] = pathwayGroup.pathwayCount;
 				row.path.forEach((p,i) => {
 					newRow[`Step ${i + 1}`] = this.pathCodeResolver(p);
 				});
 				newRow['personCount'] = row.personCount;
-				newRow['pathwayPercent'] = percentFormat(100.0 * row.personCount / d.pathwayCount);
-				newRow['cohortPercent'] = percentFormat(100.0 * row.personCount / d.cohortCount);
+				newRow['pathwayPercent'] = percentFormat(row.pathwayPercent);
+				newRow['cohortPercent'] = percentFormat(row.cohortPercent);
 
 				return newRow;
 			});
 			csvData.sort((a,b) => b.personCount - a.personCount);
-			CsvUtils.saveAsCsv(csvData);
+			CsvUtils.saveAsCsv(csvData,`${this.results.executionId}_${pathwayGroup.id}_pathways.csv`);
 		}
+		
+		getEventCohortsByRank(pathwayGroup)
+		{
+			const pathways = pathwayGroup.pathways;
+			const eventCodes = this.reportData().eventCodes;
+			let groups = pathways.reduce((acc,cur) => { // reduce pathways an Array of ranks containing a Map of counts by event cohort
+				for (let i = 0; i < cur.path.length; i++) {
+					acc[i] = acc[i] || new Map(); // allocate a map for this rank if index is missing
+					eventCodes.filter(ec => ec.isCombo == false && (ec.code & cur.path[i]) > 0).forEach(ec => {
+						if (!acc[i].has(ec.code)) {
+							acc[i].set(ec.code, {code: ec.code, rank: i+1, personCount : cur.personCount}); // copy out to new object to avoid pollution of main data object
+						} else {
+							acc[i].get(ec.code).personCount += cur.personCount;								
+						}
+					});
+				}
+				return acc;
+			}, new Array(10));
+			
+			const data = groups.reduce((acc,cur) => {
+				return acc.concat(Array.from(cur.values()));
+			},[]);
+			
+			data.forEach(row => { // add pathway and cohort percents
+				row.pathwayPercent = 100.0 * row.personCount / pathwayGroup.pathwayCount;
+				row.cohortPercent = 100.0 * row.personCount / pathwayGroup.cohortCount;
+			});
+			
+			return data;
+			
+		}
+		
+		getEventCohortByRankDatatable(pathwayGroup) {
+			let data = this.getEventCohortsByRank(pathwayGroup);
 
+			return {
+				data: data,
+				options: {
+					autoWidth:true,
+					order: [[2, 'desc']],
+					columns : [
+						columnValueBuilder("Event Cohort", "code", this.pathCodeResolver),
+						columnValueBuilder("Rank", "rank"),
+						columnValueBuilder("Count", "personCount"),
+						columnValueBuilder("% with Pathway", "pathwayPercent", percentFormat),
+						columnValueBuilder("% of Cohort", "cohortPercent", percentFormat)
+					]
+				}
+			}
+		}
+		
+		exportCountsByRank(pathwayGroup) {
+			const rawData = this.getEventCohortsByRank(pathwayGroup);
+			const csvData = rawData.map(row => {
+				const newRow = {};				
+				newRow['sourceName'] = this.results.sourceName;
+				newRow['targetId'] = pathwayGroup.id;
+				newRow['targetname'] = pathwayGroup.name;
+				newRow['cohortCount'] = pathwayGroup.cohortCount;
+				newRow['pathwayCount'] = pathwayGroup.pathwayCount;
+				newRow['eventCohort'] = this.pathCodeResolver(row.code);
+				newRow['rank'] = row.rank;
+				newRow['personCount'] = row.personCount;
+				newRow['pathwayPercent']=percentFormat(row.pathwayPercent);
+				newRow['cohortPercent']=percentFormat(row.cohortPercent);
+				return newRow;
+			})
+		
+			csvData.sort((a,b) => b.personCount - a.personCount);
+			CsvUtils.saveAsCsv(csvData,`${this.results.executionId}_${pathwayGroup.id}_EventCohortsByRank.csv`);
+		}
+		
+		getEventCohortCounts(pathwayGroup)
+		{
+			const pathways = pathwayGroup.pathways;
+			const eventCodes = this.reportData().eventCodes;
+			let dataMap = pathways.reduce((acc,cur) => { // reduce pathways an Array of ranks containing a Map of counts by event cohort
+				const visited = new Map();
+				for (let i = 0; i < cur.path.length; i++) {
+					eventCodes.filter(ec => ec.isCombo == false && (ec.code & cur.path[i]) > 0).forEach(ec => {
+						if (visited.has(ec.code)) return; // do not add this event cohort to the total if the event cohort has already been seen in this path
+						visited.set(ec.code, true);
+						if (!acc.has(ec.code)) {
+							acc.set(ec.code, {code: ec.code, personCount : cur.personCount}); // copy out to new object to avoid pollution of main data object
+						} else {
+							acc.get(ec.code).personCount += cur.personCount;								
+						}
+					});
+				}
+				return acc;
+			}, new Map());
+			
+			const data = Array.from(Array.from(dataMap.values()));
+			
+			data.forEach(row => { // add pathway and cohort percents
+				row.pathwayPercent = 100.0 * row.personCount / pathwayGroup.pathwayCount;
+				row.cohortPercent = 100.0 * row.personCount / pathwayGroup.cohortCount;
+			});
+			return data;			
+		}
+		
+		getEventCohortCountsDatatable(pathwayGroup) {
+			let data = this.getEventCohortCounts(pathwayGroup);
+
+			return {
+				data: data,
+				options: {
+					autoWidth:true,
+					order: [[1, 'desc']],
+					columns : [
+						columnValueBuilder("Event Cohort", "code", this.pathCodeResolver),
+						columnValueBuilder("Count", "personCount"),
+						columnValueBuilder("% with Pathway", "pathwayPercent", percentFormat),
+						columnValueBuilder("% of Cohort", "cohortPercent", percentFormat)
+					]
+				}
+			}
+		}
+		
+		exportEventCohortCounts(pathwayGroup) {
+			const rawData = this.getEventCohortCounts(pathwayGroup);
+			const csvData = rawData.map(row => {
+				const newRow = {};				
+				newRow['sourceName'] = this.results.sourceName;
+				newRow['targetId'] = pathwayGroup.id;
+				newRow['targetname'] = pathwayGroup.name;
+				newRow['cohortCount'] = pathwayGroup.cohortCount;
+				newRow['pathwayCount'] = pathwayGroup.pathwayCount;
+				newRow['eventCohort'] = this.pathCodeResolver(row.code);
+				newRow['personCount'] = row.personCount;
+				newRow['pathwayPercent']=percentFormat(row.pathwayPercent);
+				newRow['cohortPercent']=percentFormat(row.cohortPercent);
+				return newRow;
+			})
+		
+			csvData.sort((a,b) => b.personCount - a.personCount);
+			CsvUtils.saveAsCsv(csvData,`${this.results.executionId}_${pathwayGroup.id}_EventCohortCounts.csv`);
+		}
+		
+		getDistinctEventCohortCounts(pathwayGroup)
+		{
+			const pathways = pathwayGroup.pathways;
+			const eventCodes = this.reportData().eventCodes;
+			let dataMap = pathways.reduce((acc,cur) => { // reduce pathways an Array of ranks containing a Map of counts by event cohort
+				const visited = new Map();
+				for (let i = 0; i < cur.path.length; i++) {
+					eventCodes.filter(ec => ec.isCombo == false && (ec.code & cur.path[i]) > 0).forEach(ec => {
+						if (visited.has(ec.code)) return; // do not add this event cohort to the total if the event cohort has already been seen in this path
+						visited.set(ec.code, true);
+					});
+				}
+				
+				const eventCohorts = Array.from(visited.keys());
+				
+				if (!acc.has(eventCohorts.length)) {
+					acc.set(eventCohorts.length, {eventCohorts: eventCohorts.length, personCount : cur.personCount}); // copy out to new object to avoid pollution of main data object
+				} else {
+					acc.get(eventCohorts.length).personCount += cur.personCount;								
+				}
+				
+				return acc;
+			}, new Map());
+			
+			const data = Array.from(Array.from(dataMap.values())).concat([{eventCohorts: 0, personCount: (pathwayGroup.cohortCount - pathwayGroup.pathwayCount)}]);
+			
+			data.forEach(row => { // add pathway and cohort percents
+				row.pathwayPercent = 100.0 * row.personCount / pathwayGroup.pathwayCount;
+				row.cohortPercent = 100.0 * row.personCount / pathwayGroup.cohortCount;
+			});
+			return data;			
+		}
+		
+		getDistinctEventCohortCountsDatatable(pathwayGroup) {
+			let data = this.getDistinctEventCohortCounts(pathwayGroup);
+
+			return {
+				data: data,
+				options: {
+					autoWidth:true,
+					order: [[1, 'desc']],
+					columns : [
+						columnValueBuilder("Distinct Event Cohorts", "eventCohorts", (v) => `Exactly ${v}`),
+						columnValueBuilder("Count", "personCount"),
+						columnValueBuilder("% with Pathway", "pathwayPercent", percentFormat),
+						columnValueBuilder("% of Cohort", "cohortPercent", percentFormat)
+					]
+				}
+			}
+		}		
+		
+		exportDistinctEventCohortCounts(pathwayGroup) {
+			const rawData = this.getDistinctEventCohortCounts(pathwayGroup);
+			const csvData = rawData.map(row => {
+				const newRow = {};				
+				newRow['sourceName'] = this.results.sourceName;
+				newRow['targetId'] = pathwayGroup.id;
+				newRow['targetname'] = pathwayGroup.name;
+				newRow['cohortCount'] = pathwayGroup.cohortCount;
+				newRow['pathwayCount'] = pathwayGroup.pathwayCount;
+				newRow['eventCohorts'] = `Exactly ${row.eventCohorts}`;
+				newRow['personCount'] = row.personCount;
+				newRow['pathwayPercent']=percentFormat(row.pathwayPercent);
+				newRow['cohortPercent']=percentFormat(row.cohortPercent);
+				return newRow;
+			})
+		
+			csvData.sort((a,b) => b.personCount - a.personCount);
+			CsvUtils.saveAsCsv(csvData,`${this.results.executionId}_${pathwayGroup.id}_DistinctEventCohorts.csv`);
+		}		
+		
 	}
 	
-	return commonUtils.build('pathway-tableview', PathwayTableview, view);
+	return CommonUtils.build('pathway-tableview', PathwayTableview, view);
 });

--- a/js/pages/pathways/components/tabs/pathway-tableview.js
+++ b/js/pages/pathways/components/tabs/pathway-tableview.js
@@ -1,0 +1,153 @@
+define([
+	'knockout',
+	'components/Component',
+	'utils/AutoBind',
+	'utils/CommonUtils',
+	'text!./pathway-tableview.html',	
+	'less!./pathway-tableview.less',
+	'databindings'
+], function (
+	ko,
+	Component,
+	AutoBind,
+	commonUtils,
+	view
+) {
+	
+	const MAX_PATH_LENGTH = 10;
+	const DEFAULT_PATH_LENGTH = 5;
+	const PATH_LENGTH_OPTIONS = Array(MAX_PATH_LENGTH).fill().map((v,i)=>i + 1);
+	
+	function columnPathBuilder (label, field, resolver) {
+		return {
+			title: label,
+			data: (d) => resolver ? resolver(d.path[field]) : d.paths[field],
+			defaultContent: ''
+		};
+	}
+
+	function columnValueBuilder (label, field, formatter) {
+		return {
+			title: label,
+			data: (d) => formatter ? formatter(d[field]) : d[field],
+			defaultContent: ''
+		};
+	}
+
+	function percentFormat(v) {
+		return `${v.toFixed(2)}%`;
+	}
+
+	class PathwayTableview extends AutoBind(Component) {
+		constructor(params) {
+			super();
+			this.results = params.results;
+			this.filterList = ko.utils.unwrapObservable(params.filterList);
+			this.pathLengthOptions = PATH_LENGTH_OPTIONS;
+			this.pathLength = ko.observable(DEFAULT_PATH_LENGTH);
+			this.reportData = ko.pureComputed(() => this.prepareReportData());
+		}
+		
+		prepareReportData() {
+			const design = this.results.design;
+			const pathwayGroups = this.results.data.pathwayGroups;
+			
+			return({
+				cohorts: design.targetCohorts.filter(c => this.filterList.selectedValues().includes(c.id)).map(c => {
+					const pathwayGroup = pathwayGroups.find(p => p.targetCohortId == c.id);
+					return {
+						id: c.id, 
+						name: c.name, 
+						cohortCount: pathwayGroup.targetCohortCount, 
+						pathwayCount: pathwayGroup.totalPathwaysCount,
+						pathways: pathwayGroup.pathways
+					}
+				}),
+				eventCodes: this.results.data.eventCodes
+			});		
+		}
+		
+		pathCodeResolver(d) {
+			return this.reportData().eventCodes
+				.filter(ec => ec.isCombo == false && (ec.code & d) > 0)
+				.map(ec => ec.name)
+				.join(' + ');
+		}
+		
+		getPathwayGroupData(pathways, pathLength)
+		{
+			let data = pathways.map(p => ({
+				path : p.path.split('-',pathLength)
+					.map(p => +p)																		
+					.concat(Array(MAX_PATH_LENGTH).fill(null))
+					.slice(0,pathLength),
+				personCount: p.personCount
+			}));
+
+			let groups = data.reduce((acc,cur) => {
+				const key = JSON.stringify(cur.path);
+				if (!acc.has(key)) {
+					acc.set(key, cur);
+				} else {
+					acc.get(key).personCount += cur.personCount;
+				}
+				return acc;
+			}, new Map()).values();
+
+			return Array.from(groups);
+		}	
+		
+		getDataTableBindingData(pathwayGroup) {
+			// 'data' is based on a group-by sum of the specified path lengths
+
+			let pathCols = Array(MAX_PATH_LENGTH)
+				.fill()
+				.map((v,i) => {
+					const col = columnPathBuilder(`Step ${i+1}`, i, this.pathCodeResolver);
+					col.visible = i < this.pathLength();
+					return col;
+				});					
+			let statCols = [columnValueBuilder("Count", "personCount")];
+			let data = this.getPathwayGroupData(pathwayGroup.pathways, this.pathLength());
+
+			// add columns for % of Paths and % of cohort
+			data.forEach(row => {
+				row.pathwayPercent = 100.0 * row.personCount / pathwayGroup.pathwayCount;
+				row.cohortPercent = 100.0 * row.personCount / pathwayGroup.cohortCount;
+			});
+
+			statCols.push(columnValueBuilder("% with Pathway", "pathwayPercent", percentFormat));
+			statCols.push(columnValueBuilder("% of Cohort", "cohortPercent", percentFormat));
+
+			return {
+				data: data, //data,
+				options: {
+					autoWidth:true,
+					order: [[pathCols.length, 'desc']],
+					columnDefs: statCols.map((c,i) => ({width: "7%", targets: pathCols.length + i, className: 'stat'})),
+					columns :  [...pathCols, ...statCols]
+				}
+			}
+		}
+		
+		exportCohortReport(d) {
+			const rawData = this.getPathwayGroupData(d.pathways, this.pathLength());
+			const csvData = rawData.map(row => {
+				const newRow = {};
+				row.path.forEach((p,i) => {
+					newRow[`Step ${i + 1}`] = this.pathCodeResolver(p);
+				});
+				newRow['personCount'] = row.personCount;
+				newRow['pathwayPercent'] = percentFormat(100.0 * row.personCount / d.pathwayCount);
+				newRow['cohortPercent'] = percentFormat(100.0 * row.personCount / d.cohortCount);
+
+				return newRow;
+			});
+			csvData.sort((a,b) => b.personCount - a.personCount);
+			CsvUtils.saveAsCsv(csvData);
+		}
+
+	}
+	
+	return commonUtils.build('pathway-tableview', PathwayTableview, view);
+});

--- a/js/pages/pathways/components/tabs/pathway-tableview.less
+++ b/js/pages/pathways/components/tabs/pathway-tableview.less
@@ -2,4 +2,20 @@
 	&__export-button {
 		margin-left: 1rem;			
 	}
+
+	&__cohort-title {
+		font-size: 2.2em; 
+		font-weight: bold;
+	}
+
+	&__table-title {
+		font-size: 1.6em; 
+		font-weight: bold;
+	}
+	hr {
+			margin-top: 5px;
+			margin-bottom: 5px;
+			border: 0;
+			border-top: 1px solid #636262;
+	}
 }

--- a/js/pages/pathways/components/tabs/pathway-tableview.less
+++ b/js/pages/pathways/components/tabs/pathway-tableview.less
@@ -1,0 +1,5 @@
+.pathway-tableview {
+	&__export-button {
+		margin-left: 1rem;			
+	}
+}

--- a/js/utils/CsvUtils.js
+++ b/js/utils/CsvUtils.js
@@ -75,11 +75,11 @@ define(
         return output;
       }
 
-      static saveAsCsv(objArray, sDelimiter, cDelimiter) {
+      static saveAsCsv(objArray, fileName, sDelimiter, cDelimiter) {
         const csvText = CsvUtils.toCsv(objArray, sDelimiter, cDelimiter);
 
         const blob = new Blob([csvText], {type: "text/csv;charset=utf-8"});
-        saveAs(blob, 'data.csv');
+        saveAs(blob, fileName || 'data.csv');
       }
     }
 


### PR DESCRIPTION
References issues: #2117, #1552, #1554. #1451.

This PR's primary focus is #1552 (I gave this a bad branch name), where a tabular view of the sunburst is presented and can be exported one at a time.  I think it would be useful to support a 'export all' button but I did not get to that point.

Other issues I would like to address, but could use some help: 
#1554/#2117: I thought we had the ability to grab a SVG from the browser and save it as a PNG (like we can save a .csv file from tabular data) but I can't find where we did this.  If anyone can provide a function to do this, we can make exporting the sunburst SVG part of this PR.
_**Edit**_: I think I found it in `ChartUtils.downloadAsPng()`.

#1451/#1557: This request is more of a summary statistics view of the sunburst data, and I have some ideas about implementing this, and I'm happy to put it into this PR if time allows.

