### PR TITLE
if auth providers array is redefined in config-local.js then it is used instead of auth providers array from config.js

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -21,6 +21,9 @@ define([
 		if (key === 'externalLibraries' && _.isArray(objValue)) {
 			return objValue.concat(srcValue);
 		}
+		if (key === 'authProviders' && _.isArray(srcValue)) {
+			return srcValue;
+		}
 	};
 
 	config.webAPIRoot = config.api.url;


### PR DESCRIPTION
fixes #2371