### PR TITLE
Update 'Combination Window' description

### DIFF
--- a/js/pages/pathways/components/tabs/pathway-design.html
+++ b/js/pages/pathways/components/tabs/pathway-design.html
@@ -30,7 +30,7 @@
 		<div data-bind="css: classes('settings')">
 			<table>
 				<tr data-bind="css: classes('setting-line')">
-						<td data-bind="css: classes('setting-title')">Combination Window:</td>
+						<td data-bind="css: classes('setting-title')">Collapse Days:</td>
 						<td>
 							<input
 									class="form-control"
@@ -41,7 +41,7 @@
 										ko_autocomplete: { value: design().combinationWindow, source: combinationWindowOptions, minLength: 0, maxShowItems: 10, scroll: true }, enable:isEditPermitted()"
 							/>
 						</td>
-						<td data-bind="css: classes('setting-description')">Window of time when two event cohorts need to overlap to be considered a combination.</td>
+						<td data-bind="css: classes('setting-description')">Any dates found within the specified collapse days will be reassigned the earliest date.  Collapsing dates reduces pathway variation, leading to a reduction in 'noise' in the result.</td>
 				</tr>
 				<tr data-bind="css: classes('setting-line')">
 					<td data-bind="css: classes('setting-title')">Minimum cell count:</td>


### PR DESCRIPTION
There is some confusion when using 'combination' in the context of pathway analysis:  combinations are sometimes described in drug utilization studies separately from 'switches', so this setting makes it sound like a way to identify 'drug combination use', when the actual purpose is to 'combine dates within a proximity of each other into a single date'.   So, we're changing the wording of this to 'collapse days' and provide a description of what this setting does (it reassigns dates that are in close proximity to each other to reduce pathway variation and reduce noise.)
