### PR TITLE
issue-2410 - fix included concepts tab (#2413)

### DIFF
--- a/js/components/conceptset/ConceptSetStore.js
+++ b/js/components/conceptset/ConceptSetStore.js
@@ -18,7 +18,7 @@ define([
 	JSZip,
 ) {
 
-	const {ViewMode} = constants;
+	const { ViewMode,  RESOLVE_OUT_OF_ORDER } = constants;
 
 	// define a counter that can be 'frozen' from ConceptSetStore
 	const counter = () => {
@@ -80,11 +80,24 @@ define([
 			this.source = props.source || "unnamed";
 			this.title = props.title || "unnamed";
       
-      this.resolveCount = counter(); // handle out of order resolves
+			this.resolveCount = counter(); // handle out of order resolves
 
 			this.observer = ko.pureComputed(() => ko.toJSON(this.current() && this.current().expression.items()))
-				.extend({ rateLimit: { timeout: 1000, method: "notifyWhenChangesStop" } });
+				.extend({ rateLimit: { timeout: 500, method: "notifyWhenChangesStop" } });
 
+			// watch for any change to expression items (observer has a delay)
+			this.observer.subscribe(async () => {
+			    try {
+				    await this.resolveConceptSetExpression();
+			  	} catch (err) {
+				  	if (err !== RESOLVE_OUT_OF_ORDER)
+					  	console.info(err);
+				  	else
+					  	throw(err);
+			  	} finally {
+			  	}
+			});  
+			  
 			this.isEditable = ko.observable(false);
 		}
 

--- a/js/components/conceptset/conceptset-list.js
+++ b/js/components/conceptset/conceptset-list.js
@@ -36,7 +36,7 @@ define([
 	globalConstants
 ) {
 
-	const {ViewMode, RESOLVE_OUT_OF_ORER} = constants;
+	const {ViewMode, RESOLVE_OUT_OF_ORDER} = constants;
 	
 	class ConceptSetList extends AutoBind(Component) {
 
@@ -134,7 +134,7 @@ define([
 					await this.conceptSetStore.resolveConceptSetExpression();
 					await this.conceptSetStore.refresh(this.selectedTabKey());
 				} catch (err) {
-					if (err != RESOLVE_OUT_OF_ORER)
+					if (err != RESOLVE_OUT_OF_ORDER)
 						console.info(err);
 					else
 						throw(err);

--- a/js/components/conceptset/const.js
+++ b/js/components/conceptset/const.js
@@ -23,7 +23,7 @@ define([
 		incidenceRates: 'incidenceRates',
 	};
 	
-	const RESOLVE_OUT_OF_ORDER = 'resolveConceptSetExpression() resolved out of oder';
+	const RESOLVE_OUT_OF_ORDER = 'resolveConceptSetExpression() resolved out of order';
 
 	return {
 		importTypes,

--- a/js/pages/concept-sets/components/tabs/conceptset-expression.js
+++ b/js/pages/concept-sets/components/tabs/conceptset-expression.js
@@ -121,7 +121,6 @@ define([
       this.conceptSetItems().forEach(conceptSetItem => {
         conceptSetItem[key](!areAllSelected);
       })
-      await this.conceptSetStore.resolveConceptSetExpression();
     }
 
     navigateToSearchPage() {

--- a/js/pages/concept-sets/conceptset-manager.js
+++ b/js/pages/concept-sets/conceptset-manager.js
@@ -63,7 +63,7 @@ define([
     lodash,
 ) {
   
-  const {ViewMode, RESOLVE_OUT_OF_ORER} = constants;
+  const { ViewMode } = constants;
   
 	class ConceptsetManager extends AutoBind(Page) {
 		constructor(params) {
@@ -253,21 +253,10 @@ define([
 				createdByUsernameGetter: () => this.currentConceptSet() && this.currentConceptSet().createdBy
 			});
 
-			// watch for any change to expression items (observer has a delay)
-      this.subscriptions.push(this.conceptSetStore.observer.subscribe(async () => {
-				try {
-					await this.conceptSetStore.resolveConceptSetExpression();
-					await this.conceptSetStore.refresh(this.tabs[this.selectedTab()||0].key);
-				} catch (err) {
-					if (err != RESOLVE_OUT_OF_ORER)
-						console.info(err);
-					else
-						throw(err);
-				} finally {
-				}
-			}));  
-			
 			this.conceptSetStore.isEditable(this.canEdit());
+			this.conceptSetStore.observer.subscribe(async () => {
+					await this.conceptSetStore.refresh(this.tabs[this.selectedTab() || 0].key);
+			})
 		}
 
 		onRouterParamsChanged(params, newParams) {
@@ -327,7 +316,7 @@ define([
 		}
 
 		dispose() {
-      super.dispose();
+			super.dispose();
 			this.onConceptSetModeChanged && this.onConceptSetModeChanged.dispose();
 			this.fade(false); // To close modal immediately, otherwise backdrop will freeze and remain at new page
 			this.isOptimizeModalShown(false);


### PR DESCRIPTION
* issue-2410 - fix included concepts tab

* added condition to load included concept sets only when tab is opened

* removed logs

* issue-2410 - moved observer to conceptset-manager.js

* issue-2410 - fixed observer for conceptsets, removed redundant func call

* separate view logic from store

Co-authored-by: wivern <vitaly.koulakov@gmail.com>

(cherry picked from commit 0c7fb56)