### PR TITLE
Configure access modal fails on cohort definition load #2441

### DIFF
--- a/js/pages/cohort-definitions/cohort-definition-manager.html
+++ b/js/pages/cohort-definitions/cohort-definition-manager.html
@@ -1,12 +1,13 @@
 <loading data-bind="visible: $component.isLoading()"></loading>
+<access-denied params="isAuthenticated: isAuthenticated, isPermitted: hasAccess"></access-denied>
+
+<!-- ko if: hasAccess -->
 <div data-bind="if: currentCohortDefinition() && $root.router.currentView() == 'cohort-definition-manager' && !$component.isLoading()" class="flexed">
 	<heading-title params="name: cohortDefinitionCaption(), description: canEdit() ? '' : '(Read only)', icon: 'users', theme: 'dark'"></heading-title>
 	<!-- ko if: currentCohortDefinition() && currentCohortDefinition().id() != 0 -->
 	<!-- ko component: {name: 'authorship', params: getAuthorship()} --> <!-- /ko -->
 	<!-- /ko -->
-	<access-denied params="isAuthenticated: isAuthenticated, isPermitted: hasAccess"></access-denied>
 
-	<!-- ko if: hasAccess -->
 	<div data-bind="currentCohortDefinition() != null">
 		<div class="asset-heading">
 			<div class="input-group">
@@ -557,7 +558,7 @@
 		<b>Full Analysis</b>
 		<p>Runs a complete set of characterization reports. (estimated: 60 minutes)</p>
 	</atlas-modal>
-	<!-- /ko -->
+
 	<atlas-modal params="{
 		showModal: cohortLinkModalOpened,
 		iconClass: 'fa fa-group',
@@ -617,3 +618,5 @@
 <script type="text/html" id="failed-status-tmpl">
 	<a href='#' data-bind="css: $component.classes('status-link'), click: () => $component.showExitMessage($data.item.sourceKey), text: $data.status"></a>
 </script>
+
+<!-- /ko -->

--- a/js/pages/cohort-definitions/cohort-definition-manager.js
+++ b/js/pages/cohort-definitions/cohort-definition-manager.js
@@ -393,11 +393,12 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 				if (!this.isAuthenticated()) {
 					return false;
 				}
-				if (this.isNew()) {
+				if (this.currentCohortDefinition() && this.isNew()) {
 					return this.authApi.isPermittedCreateCohort();
 				}
 
-				return this.authApi.isPermittedReadCohort(this.currentCohortDefinition().id());
+				return this.authApi.isPermittedReadCohorts() ||
+					(this.currentCohortDefinition() && this.authApi.isPermittedReadCohort(this.currentCohortDefinition().id()));
 			});
 
 			this.hasAccessToGenerate = (sourceKey) => {

--- a/js/pages/cohort-definitions/cohort-definition-manager.js
+++ b/js/pages/cohort-definitions/cohort-definition-manager.js
@@ -410,7 +410,6 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 			this.hasAccessToReadCohortReport = (sourceKey) => {
 				return this.isAuthenticated() && this.authApi.isPermittedReadCohortReport(this.currentCohortDefinition().id(), sourceKey);
 			}
-			if (!this.hasAccess()) return;
 
 			this.renderCountColumn = datatableUtils.renderCountColumn;
 


### PR DESCRIPTION
fixes #2441

@anthonysena 
Concerning expected behavior. Read-only version available for user with "Atlas users" role. If user have only "public" role, then after the fix Atlas will show him this screen: 
![изображение](https://user-images.githubusercontent.com/765539/105194470-a93d3380-5b4a-11eb-8301-164c4ec55c3d.png)