### PR TITLE
PLE/PLP analysis TypeError Cannot read property 'filter' of undefined after closing by ‘close’ button #2447

### DIFF
--- a/js/components/analysisExecution/analysis-execution-list.js
+++ b/js/components/analysisExecution/analysis-execution-list.js
@@ -47,7 +47,11 @@ define([
     }) {
       super();
       this.analysisId = analysisId;
-      this.analysisId.subscribe(() => this.loadData());
+      this.analysisId.subscribe((id) => {
+        if (id) {
+          this.loadData();
+        }
+      });
       this.resultsPathPrefix = resultsPathPrefix;
       this.downloadApiPaths = downloadApiPaths;
       this.downloadFileName = downloadFileName;


### PR DESCRIPTION
fixes #2447 