### PR TITLE
Only add a slash to the WEBAPI_URL if it is set

### DIFF
--- a/docker/30-atlas-env-subst.sh
+++ b/docker/30-atlas-env-subst.sh
@@ -2,18 +2,17 @@
 
 set -e
 
-# make sure the WebAPI URL ends with a slash
-case $WEBAPI_URL in
-  # correct, no action
-  */)
-    ;;
-  # otherwise, add slash
-  *)
-    WEBAPI_URL="$WEBAPI_URL/"
-    ;;
-esac
-
 if [ -n "${WEBAPI_URL}" ]; then
+  # make sure the WebAPI URL ends with a slash
+  case $WEBAPI_URL in
+    # correct, no action
+    */)
+      ;;
+    # otherwise, add slash
+    *)
+      WEBAPI_URL="$WEBAPI_URL/"
+      ;;
+  esac
   CONFIG_LOCAL="/usr/share/nginx/html/atlas/js/config-local.js"
   TFILE=`mktemp`
   trap "rm -f $TFILE" 0 1 2 3 15


### PR DESCRIPTION
Otherwise, the "/" is added even if the WEBAPI_URL is empty, making it impossible to avoid running the `envsubst` command, e.g. when trying to mount a custom config-local.js as read-only.