### PR TITLE
FHIR terminology import

### DIFF
--- a/js/components/conceptset/import.js
+++ b/js/components/conceptset/import.js
@@ -12,6 +12,7 @@ define([
 	'./import/identifiers',
 	'./import/sourcecodes',
 	'./import/conceptset',
+	'./import/fhir',
 ],function(
 	ko,
 	view,
@@ -60,6 +61,12 @@ define([
 				{
 					title: ko.i18n('components.conceptSet.repository', 'Repository'),
 					key: 'repository',
+				},
+				{
+					title: ko.i18n('components.conceptSet.fhir', 'FHIR'),
+					key: 'fhir',
+					componentName: 'conceptset-list-import-fhir',
+					componentParams: {...params, appendConcepts: this.appendConcepts}
 				}
 			];
 		}

--- a/js/components/conceptset/import/fhir.html
+++ b/js/components/conceptset/import/fhir.html
@@ -1,0 +1,18 @@
+<div>
+    <div class="heading">
+        <span data-bind="text: ko.i18n('components.conceptSet.fhirHeading', 'Import a value set from a FHIR terminology server')"></span>
+    </div>
+    <label>
+        <span data-bind="text: ko.i18n('components.conceptSet.fhirServer', 'FHIR server URL')"></span>
+        <input class="form-control" type="text" name="fhirServer" data-bind="textInput: fhirServer"/>
+    </label>
+    <label>
+        <span data-bind="text: ko.i18n('components.conceptSet.valueSet', 'Value set URI')"></span>
+        <input class="form-control" type="text" name="valueSet" data-bind="textInput: valueSet"/>
+    </label>
+    <concept-add-box params="{
+        isActive: canAddConcepts,
+        onSubmit: doImport,
+      }"></concept-add-box>
+    <div class="clear"></div>
+</div>

--- a/js/components/conceptset/import/fhir.js
+++ b/js/components/conceptset/import/fhir.js
@@ -1,0 +1,51 @@
+define([
+	'knockout',
+	'text!./fhir.html',
+	'components/Component',
+	'./ImportComponent',
+	'utils/AutoBind',
+	'utils/Clipboard',
+	'utils/CommonUtils',
+	'services/VocabularyProvider',
+	'services/http',
+	'atlas-state',
+], function(
+	ko,
+	view,
+	Component,
+	ImportComponent,
+	AutoBind,
+	Clipboard,
+	commonUtils,
+	vocabularyApi,
+	httpService,
+	sharedState,
+){
+
+	class FhirImport extends AutoBind(ImportComponent(Component)) {
+		constructor(params) {
+			super(params);
+			this.fhirServer = ko.observable("https://r4.ontoserver.csiro.au/fhir");
+			this.valueSet = ko.observable("");
+			this.appendConcepts = params.appendConcepts;
+			this.canAddConcepts = ko.pureComputed(() =>
+					this.fhirServer().length > 0 &&
+					this.valueSet().length > 0 &&
+					params.canEdit()
+			);
+			this.doImport = this.doImport.bind(this);
+		}
+
+		async runImport(options) {
+			const expandUrl = `${this.fhirServer()}/ValueSet/$expand`,
+					expandParams = {
+						url: this.valueSet()
+					}, result = await httpService.doGet(expandUrl, expandParams),
+					codes = result.data.expansion.contains.map(c => c.code),
+					{data} = await vocabularyApi.getConceptsByCode(codes);
+			this.appendConcepts(data, options);
+		}
+	}
+
+	return commonUtils.build('conceptset-list-import-fhir', FhirImport, view);
+});

--- a/js/components/conceptset/import/fhir.js
+++ b/js/components/conceptset/import/fhir.js
@@ -8,7 +8,7 @@ define([
 	'utils/CommonUtils',
 	'services/VocabularyProvider',
 	'services/http',
-	'atlas-state',
+	'appConfig',
 ], function(
 	ko,
 	view,
@@ -19,13 +19,13 @@ define([
 	commonUtils,
 	vocabularyApi,
 	httpService,
-	sharedState,
+	config
 ){
 
 	class FhirImport extends AutoBind(ImportComponent(Component)) {
 		constructor(params) {
 			super(params);
-			this.fhirServer = ko.observable("https://r4.ontoserver.csiro.au/fhir");
+			this.fhirServer = ko.observable(config.fhirTerminologyUrl);
 			this.valueSet = ko.observable("");
 			this.appendConcepts = params.appendConcepts;
 			this.canAddConcepts = ko.pureComputed(() =>
@@ -40,7 +40,7 @@ define([
 			const expandUrl = `${this.fhirServer()}/ValueSet/$expand`,
 					expandParams = {
 						url: this.valueSet()
-					}, result = await httpService.doGet(expandUrl, expandParams),
+					}, result = await httpService.fhirService.doGet(expandUrl, expandParams),
 					codes = result.data.expansion.contains.map(c => c.code),
 					{data} = await vocabularyApi.getConceptsByCode(codes);
 			this.appendConcepts(data, options);

--- a/js/config/app.js
+++ b/js/config/app.js
@@ -151,5 +151,7 @@ define(function () {
      }
    };
 
+   appConfig.fhirTerminologyUrl = "https://r4.ontoserver.csiro.au/fhir";
+
 	return appConfig;
 });

--- a/js/services/http.js
+++ b/js/services/http.js
@@ -3,7 +3,7 @@ define(function(require, exports) {
   const config = require('appConfig');
   const sharedState = require('atlas-state');
   const { Api:OHDSIApi, STATUS } = require('ohdsi-api');
-  const JSON_RESPONSE_TYPE = 'application/json';
+  const FHIR_JSON_RESPONSE_TYPE = 'application/fhir+json';
   const TEXT_RESPONSE_TYPE = 'text/plain';
   const EventBus = require('services/EventBus');
 
@@ -100,6 +100,18 @@ define(function(require, exports) {
     }
   }
 
+  class FhirApi extends Api {
+    getHeaders(requestUrl) {
+      return {
+        'Accept': FHIR_JSON_RESPONSE_TYPE,
+      };
+    }
+
+    parseResponse(json) {
+      return JSON.parse(json);
+    }
+  }
+
   const singletonApi = new Api();
   singletonApi.setAuthTokenHeader('Authorization');
   
@@ -108,7 +120,10 @@ define(function(require, exports) {
   plainTextService.setUnauthorizedHandler(() => singletonApi.handleUnauthorized());
   plainTextService.setUserTokenGetter(() => singletonApi.getUserToken());
 
+  const fhirService = new FhirApi();
+
   singletonApi.plainTextService = plainTextService;
+  singletonApi.fhirService = fhirService;
 
   return singletonApi;
 });


### PR DESCRIPTION
This change adds a tab to the Import section of the Concept Sets area.

A user can enter:

1. The URL of a [FHIR terminology server](https://hl7.org/fhir/R4/terminology-service.html), and;
2. A URI describing a FHIR [ValueSet](https://www.hl7.org/fhir/R4/valueset.html) known to that terminology server.

A request will be made to the ValueSet [expand](https://hl7.org/fhir/R4/valueset-operation-expand.html) operation on that server, and the resulting codes will be imported.

#### Limitations

- Matching is done on code only, in the same way the "Source Codes" import currently works. This could be enhanced when a proper mapping of FHIR code system identifiers to OMOP vocabulary identifiers is available, which is [currently being worked on](https://chat.fhir.org/#narrow/stream/179202-terminology/topic/OMOP.20Standard.20Terminologies).