### PR TITLE
Fixed invalid redirect for /atlas without trailing slash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN find . -type f "(" \
       | xargs -0 -n 1 gzip -kf
 
 # Production Nginx image
-FROM nginxinc/nginx-unprivileged:1.20-alpine
+FROM nginxinc/nginx-unprivileged:1.23.0-alpine
 
 LABEL org.opencontainers.image.title="OHDSI-Atlas"
 LABEL org.opencontainers.image.authors="Joris Borgdorff <joris@thehyve.nl>, Lee Evans - www.ltscomputingllc.com"
@@ -41,6 +41,7 @@ ENV WEBAPI_URL=http://localhost:8080/WebAPI/ \
   CONFIG_PATH=/etc/atlas/config-local.js
 
 # Configure webserver
+COPY ./docker/nginx-default.conf /etc/nginx/conf.d/default.conf
 COPY ./docker/optimization.conf /etc/nginx/conf.d/optimization.conf
 COPY ./docker/30-atlas-env-subst.sh /docker-entrypoint.d/30-atlas-env-subst.sh
 

--- a/docker/nginx-default.conf
+++ b/docker/nginx-default.conf
@@ -1,0 +1,18 @@
+server {
+    listen       8080;
+
+    root /usr/share/nginx/html;
+
+    location ~ ^.*[^/]$ {
+        try_files $uri @rewrite;
+    }
+
+    location @rewrite {
+        return 302 $scheme://$http_host$uri/;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
Closes #2641

When accessing the Atlas UI on a URL *not* ending in a trailing slash, NGINX would always automatically redirect you to `host:8080/atlas/`.

This change modifies the default NGINX configuration to use the host header for redirection.