### PR TITLE
 i18n problem with lodash templates #2745

### DIFF
--- a/js/extensions/bindings/i18nBinding.js
+++ b/js/extensions/bindings/i18nBinding.js
@@ -25,7 +25,8 @@ define(['knockout', 'atlas-state', 'lodash'],
 			return ko.pureComputed(() => {
 				const tmpl = ko.i18n(key, defaultValue);
 				const unwrappedOptions = mapValues(options, ko.unwrap);
-				return template(ko.unwrap(tmpl))(unwrappedOptions);
+				let compiledTemplate = template(ko.unwrap(tmpl), {sourceURL: 'i18n/templates[' + key + ']'});
+				return compiledTemplate(unwrappedOptions);
 			});
 		};
 

--- a/js/extensions/bindings/i18nBinding.js
+++ b/js/extensions/bindings/i18nBinding.js
@@ -25,7 +25,7 @@ define(['knockout', 'atlas-state', 'lodash'],
 			return ko.pureComputed(() => {
 				const tmpl = ko.i18n(key, defaultValue);
 				const unwrappedOptions = mapValues(options, ko.unwrap);
-				let compiledTemplate = template(ko.unwrap(tmpl), {sourceURL: 'i18n/templates[' + key + ']'});
+				const compiledTemplate = template(ko.unwrap(tmpl), {sourceURL: 'i18n/templates[' + key + ']'});
 				return compiledTemplate(unwrappedOptions);
 			});
 		};


### PR DESCRIPTION
Fixes #2745.

Lodash templates cache moved to i18n/templates. Templates duplication is fixed, now caching only unique templates by message key - maximum number of cached templates is a number of parametrized i18n messages (which is now around several tens).