### PR TITLE
 Typo - Export / Text View - Cohort Exit - suply #2750: fix default i18n

### DIFF
--- a/js/components/cohortbuilder/components/CustomEraStrategyTemplate.html
+++ b/js/components/cohortbuilder/components/CustomEraStrategyTemplate.html
@@ -41,7 +41,7 @@
 		<!-- ko ifnot: strategy().DaysSupplyOverride() == null  -->
 		<li class="criteriaSection">
 			<span
-				data-bind="text: ko.i18n('components.customEraStrategy.customEraStrategyText_10', 'Force drug exposure days suply to:')"></span>
+				data-bind="text: ko.i18n('components.customEraStrategy.customEraStrategyText_10', 'Force drug exposure days supply to:')"></span>
 			<span contenteditable="true" class="numericInputField dropdown"
 				data-bind="htmlValue: strategy().DaysSupplyOverride.numeric(), eventType:'blur', ko_autocomplete: { value: strategy().DaysSupplyOverride, source: $component.options.dayOptions, minLength: 0, maxShowItems: 10, scroll: true }"></span>
 			<span data-bind="text: ko.i18n('components.customEraStrategy.customEraStrategyText_11', 'days.')"></span>

--- a/js/components/cohortdefinitionviewer/components/CustomEraStrategyTemplate.html
+++ b/js/components/cohortdefinitionviewer/components/CustomEraStrategyTemplate.html
@@ -31,7 +31,7 @@
     <!-- /ko -->
 		<!-- ko ifnot: strategy().DaysSupplyOverride() == null  -->
 		<li>
-			<span data-bind="text: ko.i18n('components.customEraStrategy.customEraStrategyText_19', 'forcing drug exposure days suply to:')"></span>
+			<span data-bind="text: ko.i18n('components.customEraStrategy.customEraStrategyText_19', 'forcing drug exposure days supply to:')"></span>
 			 
 			<span data-bind="text: ko.unwrap(strategy().DaysSupplyOverride)"/> 
 			<span data-bind="text: ko.i18n('common.days', 'days.')"></span>


### PR DESCRIPTION
The PR doesn't fix the issue, it just corrects default i18n text in the cohort builder. See the main fix here: OHDSI/circe-be#175