### PR TITLE
 Cannot export PLP/PLE after second save #2760

### DIFF
--- a/js/pages/estimation/cca-manager.js
+++ b/js/pages/estimation/cca-manager.js
@@ -264,6 +264,11 @@ define([
 
 		prepForSave() {
 			const specification = ko.toJS(this.estimationAnalysis());
+
+			// createdBy/modifiedBy INSIDE the spec should not be objects, just a string
+			specification.createdBy = this.estimationAnalysis().createdBy ? this.estimationAnalysis().createdBy.login : null;
+			specification.modifiedBy = this.estimationAnalysis().modifiedBy ? this.estimationAnalysis().modifiedBy.login : null;
+
 			specification.cohortDefinitions = [];
 			specification.conceptSets = [];
 			specification.conceptSetCrossReference = [];

--- a/js/pages/prediction/prediction-manager.js
+++ b/js/pages/prediction/prediction-manager.js
@@ -329,6 +329,11 @@ define([
 
 		prepForSave() {
 			const specification = ko.toJS(this.patientLevelPredictionAnalysis());
+
+			// createdBy/modifiedBy INSIDE the spec should not be objects, just a string
+			specification.createdBy = this.patientLevelPredictionAnalysis().createdBy ? this.patientLevelPredictionAnalysis().createdBy.login : null;
+			specification.modifiedBy = this.patientLevelPredictionAnalysis().modifiedBy ? this.patientLevelPredictionAnalysis().modifiedBy.login : null;
+
 			specification.targetIds = [];
 			specification.outcomeIds = [];
 			specification.cohortDefinitions = [];


### PR DESCRIPTION
Fixes #2760

`createdBy` and `modifiedBy` as objects stored outside the specification of PLP/PLE. Inside the spec server expect just a string.