### PR TITLE
Reset feature analyses parameters after submission

### DIFF
--- a/js/pages/characterizations/components/characterizations/characterization-view-edit/characterization-params-create-modal.js
+++ b/js/pages/characterizations/components/characterizations/characterization-view-edit/characterization-params-create-modal.js
@@ -36,6 +36,12 @@ define([
                 name: this.paramName(),
                 value: this.paramValue()
             });
+            this.resetParams();
+        }
+
+        resetParams() {
+            this.paramName('')
+            this.paramValue('')
         }
     }
 


### PR DESCRIPTION
At the Characterizations menu -> Feature analyzes parameters section, click New parameter -> After creating and clicking new parameter again -> Modal still displays the old value.