### PR TITLE
Adds #2845: disableBrowserCheck to allow override of browser warning

### DIFF
--- a/js/config/app.js
+++ b/js/config/app.js
@@ -6,6 +6,7 @@ define(function () {
         name: 'Local',
         url: 'http://localhost:8080/WebAPI/'
     };
+    appConfig.disableBrowserCheck = false; // browser check will happen by default
     appConfig.cacheSources = false;
     appConfig.pollInterval = 60000;
 	appConfig.cohortComparisonResultsEnabled = false;

--- a/js/utils/BrowserDetection.js
+++ b/js/utils/BrowserDetection.js
@@ -1,7 +1,9 @@
 
 const browserInfo = bowser.getParser(navigator.userAgent).getBrowser();
 const isBrowserSupported = browserInfo.name.toLowerCase() === 'chrome' && parseInt(browserInfo.version) > 63;
-toggleWarning(isBrowserSupported);
+if (!config.disableBrowserCheck) {
+    toggleWarning(isBrowserSupported);
+}
 
 function toggleWarning(doHide) {
 


### PR DESCRIPTION
Added disableBrowserCheck to app config. Uses this value to pre-empt toggling the browser warning. 