### PR TITLE
Adds ability to disable browser check via config

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 	</head>
 
 	<body class="app">
-	<div id="b-alarm" style="display: none" class="browser-alarm">
+	<div id="b-alarm" style="display: none" class="browser-alarm" data-bind="visible: toggleBrowserWarning(bowser)">
 		<div class="browser-alarm__warning-text" data-bind="text: ko.i18n('commonErrors.browserWarning', 'Note that only Chrome browser newer than v.63 is officially supported')">
 			Note that only Chrome browser newer than v.63 is officially supported
 		</div>
@@ -120,7 +120,6 @@
 
 	<!-- bundled mode -->
 	<!-- <script data-main="js/assets/bundle/bundle" src="js/require.js"></script>-->
-	<script src="js/utils/BrowserDetection.js"></script>
 
 </body>
 

--- a/js/Application.js
+++ b/js/Application.js
@@ -60,6 +60,11 @@ define(
 					return sharedState.appInitializationStatus() != constants.applicationStatuses.initializing;
 				});
 
+				this.toggleBrowserWarning = function(bowser) {
+					const browserInfo = bowser.getParser(navigator.userAgent).getBrowser();
+					const isBrowserSupported = browserInfo.name.toLowerCase() === 'chrome' && parseInt(browserInfo.version) > 63;
+					return !config.disableBrowserCheck && !isBrowserSupported;
+				}
 
 				this.appInitializationStatus = sharedState.appInitializationStatus;
 				this.noSourcesAvailable = ko.pureComputed(() => {

--- a/js/config/app.js
+++ b/js/config/app.js
@@ -6,6 +6,7 @@ define(function () {
         name: 'Local',
         url: 'http://localhost:8080/WebAPI/'
     };
+    appConfig.disableBrowserCheck = false; // browser check will happen by default
     appConfig.cacheSources = false;
     appConfig.pollInterval = 60000;
 	appConfig.cohortComparisonResultsEnabled = false;

--- a/js/utils/BrowserDetection.js
+++ b/js/utils/BrowserDetection.js
@@ -1,9 +1,0 @@
-
-const browserInfo = bowser.getParser(navigator.userAgent).getBrowser();
-const isBrowserSupported = browserInfo.name.toLowerCase() === 'chrome' && parseInt(browserInfo.version) > 63;
-toggleWarning(isBrowserSupported);
-
-function toggleWarning(doHide) {
-
-    document.getElementById("b-alarm").style.display = (doHide ? "none" : "flex");
-}


### PR DESCRIPTION
For #2845: adds a config setting named "disableBrowserCheck", which will default to false (meaning, run the browser check and toggle the warning if not a supported browser). Setting this to true will disable the browser check and warning.

To do this, I removed the existing BrowserDetection JS script and instead have a knockout data bind that runs toggleBrowserWarning() to handle this decision. 