### PR TITLE
Prevent multiple calls to concept set list when loading cohort editor

### DIFF
--- a/js/components/atlas.cohort-editor.html
+++ b/js/components/atlas.cohort-editor.html
@@ -17,6 +17,7 @@
 					<div class="modal-header" data-bind="text: ko.i18n('components.atlasCohortEditor.importConceptSet', 'Import Concept Set From Repository...')"></div>
 					<div class="paddedWrapper">
 						<concept-set-browser params="
+							showModal: $component.showModal,
 							criteriaContext: $component.criteriaContext,
 							cohortConceptSets: $component.currentCohortDefinition().expression().ConceptSets,
 							onActionComplete: $component.onAtlasConceptSetSelectAction,

--- a/js/components/atlas.cohort-editor.html
+++ b/js/components/atlas.cohort-editor.html
@@ -12,12 +12,12 @@
 		<cohort-expression-viewer params="expression: $component.currentCohortDefinition().expression"></cohort-expression-viewer>
 		<!-- /ko -->
 		<div class="modal fade" data-bind="modal: showModal" tabindex="-1" role="dialog">
+			<!-- ko if:showModal-->
 			<div class="modal-dialog modal-lg">
 				<div class="modal-content">
 					<div class="modal-header" data-bind="text: ko.i18n('components.atlasCohortEditor.importConceptSet', 'Import Concept Set From Repository...')"></div>
 					<div class="paddedWrapper">
 						<concept-set-browser params="
-							showModal: $component.showModal,
 							criteriaContext: $component.criteriaContext,
 							cohortConceptSets: $component.currentCohortDefinition().expression().ConceptSets,
 							onActionComplete: $component.onAtlasConceptSetSelectAction,
@@ -28,6 +28,7 @@
 					</div>
 				</div>
 			</div>
+			<!-- /ko -->
 		</div>
 	</div>
 </div>

--- a/js/components/circe/components/ConceptSetBrowser.js
+++ b/js/components/circe/components/ConceptSetBrowser.js
@@ -13,6 +13,7 @@ define([
 ], function (ko, template, VocabularyProvider, appConfig, ConceptSet, authApi, datatableUtils, commonUtils) {
 	function CohortConceptSetBrowser(params) {
 		var self = this;
+		var subscriptions = [];
 
 		function defaultRepositoryConceptSetSelected(conceptSet, source) {
 			// Default functionality
@@ -132,11 +133,13 @@ define([
 		if (self.isComponentUsedAsModal()) {
 			// Add subscription to load concept set
 			// list when the modal is displayed
-			self.showModal.subscribe(() => {
-				if (self.showModal()){
-					self.loadConceptSetsFromRepository(self.selectedSource().url);
-				}
-			});
+			subscriptions.push(
+				self.showModal.subscribe(() => {
+					if (self.showModal()){
+						self.loadConceptSetsFromRepository(self.selectedSource().url);
+					}
+				})
+			);
 		} else {
 			// startup actions
 			self.loadConceptSetsFromRepository(self.selectedSource().url);
@@ -188,6 +191,10 @@ define([
 				render: datatableUtils.getCreatedByFormatter(),
 			}
 		]);
+		
+		self.dispose = () => {
+			subscriptions.forEach(sub => sub.dispose());
+		}
 
 		const { pageLength, lengthMenu } = commonUtils.getTableOptions('M');
 		this.pageLength = params.pageLength || pageLength;

--- a/js/components/circe/components/ConceptSetBrowser.js
+++ b/js/components/circe/components/ConceptSetBrowser.js
@@ -13,7 +13,6 @@ define([
 ], function (ko, template, VocabularyProvider, appConfig, ConceptSet, authApi, datatableUtils, commonUtils) {
 	function CohortConceptSetBrowser(params) {
 		var self = this;
-		var subscriptions = [];
 
 		function defaultRepositoryConceptSetSelected(conceptSet, source) {
 			// Default functionality
@@ -80,10 +79,6 @@ define([
 		self.repositoryConceptSetTableId = params.repositoryConceptSetTableId || "repositoryConceptSetTable";
 
 		self.loading = ko.observable(false);
-		self.showModal = params.showModal;
-		self.isComponentUsedAsModal = ko.pureComputed(function() {
-			return(ko.isObservable(self.showModal))
-		});
 		self.repositoryConceptSets = ko.observableArray();
 		self.isProcessing = ko.observable(false);
 
@@ -130,20 +125,8 @@ define([
 
 		// dispose subscriptions
 
-		if (self.isComponentUsedAsModal()) {
-			// Add subscription to load concept set
-			// list when the modal is displayed
-			subscriptions.push(
-				self.showModal.subscribe(() => {
-					if (self.showModal()){
-						self.loadConceptSetsFromRepository(self.selectedSource().url);
-					}
-				})
-			);
-		} else {
-			// startup actions
-			self.loadConceptSetsFromRepository(self.selectedSource().url);
-		}
+		// startup actions
+		self.loadConceptSetsFromRepository(self.selectedSource().url);
 
 		this.options = {
 			Facets: [
@@ -192,10 +175,6 @@ define([
 			}
 		]);
 		
-		self.dispose = () => {
-			subscriptions.forEach(sub => sub.dispose());
-		}
-
 		const { pageLength, lengthMenu } = commonUtils.getTableOptions('M');
 		this.pageLength = params.pageLength || pageLength;
 		this.lengthMenu = params.lengthMenu || lengthMenu;

--- a/js/components/circe/components/ConceptSetBrowser.js
+++ b/js/components/circe/components/ConceptSetBrowser.js
@@ -79,6 +79,10 @@ define([
 		self.repositoryConceptSetTableId = params.repositoryConceptSetTableId || "repositoryConceptSetTable";
 
 		self.loading = ko.observable(false);
+		self.showModal = params.showModal;
+		self.isComponentUsedAsModal = ko.pureComputed(function() {
+			return(ko.isObservable(self.showModal))
+		});
 		self.repositoryConceptSets = ko.observableArray();
 		self.isProcessing = ko.observable(false);
 
@@ -125,9 +129,18 @@ define([
 
 		// dispose subscriptions
 
-		// startup actions
-		self.loadConceptSetsFromRepository(self.selectedSource()
-			.url);
+		if (self.isComponentUsedAsModal()) {
+			// Add subscription to load concept set
+			// list when the modal is displayed
+			self.showModal.subscribe(() => {
+				if (self.showModal()){
+					self.loadConceptSetsFromRepository(self.selectedSource().url);
+				}
+			});
+		} else {
+			// startup actions
+			self.loadConceptSetsFromRepository(self.selectedSource().url);
+		}
 
 		this.options = {
 			Facets: [

--- a/js/components/from-reusables-modal/from-reusables-modal.html
+++ b/js/components/from-reusables-modal/from-reusables-modal.html
@@ -50,12 +50,12 @@
 </atlas-modal>
 
 <div data-bind="modal: showCsBrowser" class="modal fade cs-modal" tabindex="-1" role="dialog">
+    <!-- ko if:showCsBrowser-->
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header" data-bind="text: ko.i18n('components.conceptSetBuilder.selectConceptSet', 'Select Concept Set...')"></div>
             <div class="paddedWrapper">
                 <concept-set-browser params="
-                        showModal: showCsBrowser,
                         repositoryConceptSetTableId: generateCsTableId(),
                         criteriaContext: criteriaContext,
                         cohortConceptSets: ko.observableArray(),
@@ -63,4 +63,5 @@
             </div>
         </div>
     </div>
+    <!-- /ko -->
 </div>

--- a/js/components/from-reusables-modal/from-reusables-modal.html
+++ b/js/components/from-reusables-modal/from-reusables-modal.html
@@ -55,6 +55,7 @@
             <div class="modal-header" data-bind="text: ko.i18n('components.conceptSetBuilder.selectConceptSet', 'Select Concept Set...')"></div>
             <div class="paddedWrapper">
                 <concept-set-browser params="
+                        showModal: showCsBrowser,
                         repositoryConceptSetTableId: generateCsTableId(),
                         criteriaContext: criteriaContext,
                         cohortConceptSets: ko.observableArray(),

--- a/js/extensions/bindings/datatableBinding.js
+++ b/js/extensions/bindings/datatableBinding.js
@@ -298,7 +298,7 @@ define([
 			table.clear();
 
 			// Rebuild table from data source specified in binding
-			if (data.length > 0)
+			if (data && data.length > 0)
 				table.rows.add(data);
 
 			// drawing may access observables, which updating we do not want to trigger a redraw to the table

--- a/js/services/AuthAPI.js
+++ b/js/services/AuthAPI.js
@@ -517,7 +517,9 @@ define(function(require, exports) {
 
     const executeWithRefresh = async function(httpPromise) {
         const result = await httpPromise;
-        await refreshToken();
+        if (config.userAuthenticationEnabled) {
+            await refreshToken();
+        }
         return result;
     }
 


### PR DESCRIPTION
Aims to fix #2887 by extending the concept set browser to only load the repository concept set list when the modal is activated.