### PR TITLE
Data Sources reports bug fixes

### DIFF
--- a/js/components/faceted-datatable.js
+++ b/js/components/faceted-datatable.js
@@ -18,7 +18,7 @@ define(['knockout', 'text!./faceted-datatable.html', 'crossfilter', 'utils/Commo
 				return [];
 			}
 		});
-		self.componentLoading = ko.observable(false);
+		self.componentLoading = ko.observable(true);
 		self.facets = ko.observableArray();
 		
 		self.nullFacetLabel = params.nullFacetLabel || 'NULL';

--- a/js/components/faceted-datatable.js
+++ b/js/components/faceted-datatable.js
@@ -18,7 +18,7 @@ define(['knockout', 'text!./faceted-datatable.html', 'crossfilter', 'utils/Commo
 				return [];
 			}
 		});
-		self.componentLoading = ko.observable(true);
+		self.componentLoading = ko.observable(false);
 		self.facets = ko.observableArray();
 		
 		self.nullFacetLabel = params.nullFacetLabel || 'NULL';

--- a/js/components/reports/classes/Treemap.js
+++ b/js/components/reports/classes/Treemap.js
@@ -146,10 +146,10 @@ define([
 			data
 		}) {
 			const normalizedData = atlascharts.chart.normalizeDataframe(ChartUtils.normalizeArray(data, true));
+			let tableData = [];
 
 			if (!normalizedData.empty) {
 				let distinctConceptIds = new Set([]);
-				let tableData = [];
 				// Make the values unique per https://github.com/OHDSI/Atlas/issues/913
 				normalizedData.conceptPath.forEach((d, i) => {
 					if (!distinctConceptIds.has(normalizedData.conceptId[i])) {
@@ -165,14 +165,13 @@ define([
 						});
 					}
 				});
-				this.tableData(tableData); 
 				this.treeData(normalizedData);
-
-				return {
-					data
-				};
 			}
+			this.tableData(tableData);
 
+			return {
+				data
+			};
 		}
 
 		getData() {

--- a/js/components/reports/reportDrilldown.js
+++ b/js/components/reports/reportDrilldown.js
@@ -234,7 +234,7 @@ define([
 					this.chartFormats.frequencyDistribution.yMax = yScaleMax;
 					this.chartFormats.frequencyDistribution.xLabel = ko.pureComputed(function () {
 						return ko.i18n('dataSources.drilldown.chartFormat.frequencyDistribution.xLabel1', 'Count ("x" or more ')() +
-							report() +
+							report +
 							ko.i18n('dataSources.drilldown.chartFormat.frequencyDistribution.xLabel2', 's)')();
 					});
 					this.chartFormats.frequencyDistribution.ticks = Math.min(5, frequencyHistogram.INTERVALS);


### PR DESCRIPTION
This PR fixes 2 different UI bugs that I have encountered in using the Atlas Data Sources reports.

- If the request to get the data for a report for some reason returns an empty array, the tabular view showed a perpetual spinner. I have update the TreeMap.js code to set the tableData parameter to an empty array in this case so that the code that turns off the spinner has an opportunity to execute.

- The frequency distribution report failed to display because there was a bug in how the chart's x-axis label is generated. A recent PR changed the `parseFrequencyDistribution` function signature so that it now passes in a string, rather than a function, for the `report` parameter. (https://github.com/OHDSI/Atlas/pull/2806/files#diff-ea4bfc7a6c32110ea437c23665e2c52aea4d576102f87d5f808e40eead045176L284)