### PR TITLE
Change concept set display in patient profile - fixes #2815

### DIFF
--- a/js/pages/profiles/profile-manager.js
+++ b/js/pages/profiles/profile-manager.js
@@ -205,7 +205,7 @@ define([
 							return (_.chain(this.conceptSets())
 								.map(function (ids, conceptSetName) {
 									if (_.includes(ids, d.conceptId))
-										return '<i class="fa fa-shopping-cart"></i> ' + conceptSetName;
+										return conceptSetName + " (Concept Set)";
 								})
 								.compact()
 								.value()


### PR DESCRIPTION
Removes the HTML and instead shows the concept set name with the "(Concept Set)" suffix to distinguish it from the single concepts that appear in the event highlighting.