### PR TITLE
Clearer table boundaries on generate UI

### DIFF
--- a/js/pages/cohort-definitions/cohort-definition-manager.css
+++ b/js/pages/cohort-definitions/cohort-definition-manager.css
@@ -100,13 +100,20 @@
 .only-results-checkbox {
 }
 table.sources-table td.generation-buttons-column {
-    text-align: right;
+    text-align: left;
 }
 table.sources-table thead th, table.sources-table tbody tr:first-child td {
     padding: 4px 10px;
 }
+table.sources-table tr {
+    transition: background-color 0.3s ease; /* Smooth transition for hover effect */
+}
+table.sources-table tr:hover {
+    background-color: #f2f2f2; 
+}
 table.sources-table tbody td {
     padding: 0 10px 4px;
+    border-bottom: solid 1px #ccc;
 }
 .generation-buttons {
     white-space: nowrap;

--- a/js/pages/cohort-definitions/cohort-definition-manager.css
+++ b/js/pages/cohort-definitions/cohort-definition-manager.css
@@ -111,9 +111,12 @@ table.sources-table tr {
 table.sources-table tr:hover {
     background-color: #f2f2f2; 
 }
+table.sources-table tr:hover td {
+    border-top: solid 1px #ccc;      
+    border-bottom: solid 1px #ccc;      
+}
 table.sources-table tbody td {
     padding: 0 10px 4px;
-    border-bottom: solid 1px #ccc;
 }
 .generation-buttons {
     white-space: nowrap;

--- a/js/pages/cohort-definitions/cohort-definition-manager.js
+++ b/js/pages/cohort-definitions/cohort-definition-manager.js
@@ -583,6 +583,10 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 
 			this.sourcesTableOptions = commonUtils.getTableOptions('S');
 			this.sourcesColumns = [{
+				sortable: false,
+				className: 'generation-buttons-column',
+				render: () => `<span data-bind="template: { name: 'generation-buttons', data: $data }"></span>`
+			}, {
 				title: `<span>${ko.i18n('cohortDefinitions.cohortDefinitionManager.panels.sourceName', 'Source Name')()}</span>`,
 				data: 'name'
 			}, {
@@ -600,10 +604,6 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 			}, {
 				title: ko.i18n('cohortDefinitions.cohortDefinitionManager.panels.generationDuration', 'Generation Duration'),
 				data: 'executionDuration'
-			}, {
-				sortable: false,
-				className: 'generation-buttons-column',
-				render: () => `<span data-bind="template: { name: 'generation-buttons', data: $data }"></span>`
 			}];
 
 			this.stopping = ko.pureComputed(() => this.cohortDefinitionSourceInfo().reduce((acc, target) => ({...acc, [target.sourceKey]: ko.observable(false)}), {}));

--- a/js/pages/incidence-rates/components/iranalysis/components/results.js
+++ b/js/pages/incidence-rates/components/iranalysis/components/results.js
@@ -116,6 +116,10 @@ define([
 			this.showOnlySourcesWithResults = ko.observable(false);
 			this.sourcesTableOptions = commonUtils.getTableOptions('S');
 			this.sourcesColumns = [{
+				sortable: false,
+				className: 'generation-buttons-column',
+				render: () => `<span data-bind="template: { name: 'generation-buttons', data: $data }"></span>`
+			}, {
 				title: ko.i18n('cohortDefinitions.cohortDefinitionManager.panels.sourceName', 'Source Name'),
 				render: (s,p,d) => `${d.source.sourceName}`
 			}, {
@@ -144,10 +148,6 @@ define([
 			}, {
 				title: ko.i18n('ir.results.duration', 'Duration'),
 				render: (s,p,d) => d.info() ? `${this.msToTime(d.info().executionInfo.executionDuration)}` : `n/a`
-			}, {
-				sortable: false,
-				className: 'generation-buttons-column',
-				render: () => `<span data-bind="template: { name: 'generation-buttons', data: $data }"></span>`
 			}];
 		}
 

--- a/js/pages/incidence-rates/components/iranalysis/components/results.less
+++ b/js/pages/incidence-rates/components/iranalysis/components/results.less
@@ -25,8 +25,18 @@
     tbody tr td {
       padding: 0 10px 4px;
     }
+    tr {
+      transition: background-color 0.3s ease; /* Smooth transition for hover effect */
+    }
+    tr:hover {
+      background-color: #f2f2f2; 
+    }
+    tr:hover td {
+      border-top: solid 1px #ccc;      
+      border-bottom: solid 1px #ccc;      
+    }
     .generation-buttons-column {
-      text-align: right;
+      text-align: left;
     }
     .generation-buttons {
       white-space: nowrap;


### PR DESCRIPTION
Modifies the cohort generation & IR generation displays based on #2878. From the issue description:

> 1. Hover Style: if the row that you were hovering was highlighted, you could see that a generate button is associated with a source more clearly.
> 2. Re-arrange columns: move Generate button to first column so the button is right next to the source
> 3. Table Style: add borders to table to see the alignment better.

The generation buttons are moved to the left (along with other buttons since those are all in the same HTML template). In this PR, I added the hover style (see below) and opted to add the borders on hover. We could always display the border but thought this might work as well and keep the table looking clean.

![image](https://github.com/user-attachments/assets/009d4103-303e-4a75-8697-e67aba963ddf)

Same changes were done for the IR display in this PR:

![image](https://github.com/user-attachments/assets/6611bad3-ae0a-4968-9a7a-25c25c1f170f)

