### PR TITLE
Extending the Cohort Generation page with a pertaining cohort covariates checkbox

### DIFF
--- a/js/pages/cohort-definitions/cohort-definition-manager.css
+++ b/js/pages/cohort-definitions/cohort-definition-manager.css
@@ -120,11 +120,5 @@ table.sources-table tbody td {
 }
 .generation-buttons {
     white-space: nowrap;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-.generation-span {
-    margin-right: 10px;
 }
   

--- a/js/pages/cohort-definitions/cohort-definition-manager.css
+++ b/js/pages/cohort-definitions/cohort-definition-manager.css
@@ -102,9 +102,6 @@
 table.sources-table td.generation-buttons-column {
     text-align: left;
 }
-.text-center {
-    text-align: center;
-}
 table.sources-table thead th, table.sources-table tbody tr:first-child td {
     padding: 4px 10px;
 }

--- a/js/pages/cohort-definitions/cohort-definition-manager.css
+++ b/js/pages/cohort-definitions/cohort-definition-manager.css
@@ -120,5 +120,11 @@ table.sources-table tbody td {
 }
 .generation-buttons {
     white-space: nowrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.generation-span {
+    margin-right: 10px;
 }
   

--- a/js/pages/cohort-definitions/cohort-definition-manager.css
+++ b/js/pages/cohort-definitions/cohort-definition-manager.css
@@ -102,6 +102,9 @@
 table.sources-table td.generation-buttons-column {
     text-align: left;
 }
+.text-center {
+    text-align: center;
+}
 table.sources-table thead th, table.sources-table tbody tr:first-child td {
     padding: 4px 10px;
 }

--- a/js/pages/cohort-definitions/cohort-definition-manager.html
+++ b/js/pages/cohort-definitions/cohort-definition-manager.html
@@ -768,9 +768,6 @@
 
 <script type="text/html" id="generation-buttons">
 	<div class="generation-buttons">
-		<span class="generation-span" data-bind="tooltip: 'Save Covariates'">
-			<input type="checkbox" id="generation-checkbox" class="generation-checkbox" data-bind="checked: $component.getRetainCohortCovariates($data)"/>
-		</span>
 		<span data-bind="tooltip: $component.isNew() ? 'You must save the current cohort definition before you can perform generation' : !$component.hasAccessToGenerate(sourceKey) ? 'Not enough permissions to generate' : null" data-placement="left">
 			<span data-bind="tooltip: !$component.canGenerate() ? $component.generateDisabledReason() : null" data-placement="left">
 				<button class="btn btn-sm btn-primary"
@@ -794,6 +791,12 @@
 											: ko.i18n('cohortDefinitions.cohortDefinitionManager.panels.viewReports', 'View Reports'))"></span>
 		</button>
 	</div>
+</script>
+
+<script type="text/html" id="generation-checkbox-retainCovariate">
+	<span>
+		<input class="hover-toolbox" type="checkbox" data-bind="attr:{ id: $data.sourceKey } , checked: $component.getRetainCohortCovariates($data), tooltip: 'Generate with Retain Covariates'" data-placement="right"/>
+	</span>
 </script>
 
 <!-- /ko -->

--- a/js/pages/cohort-definitions/cohort-definition-manager.html
+++ b/js/pages/cohort-definitions/cohort-definition-manager.html
@@ -793,10 +793,13 @@
 	</div>
 </script>
 
-<script type="text/html" id="generation-checkbox-retainCovariate">
+<script type="text/html" id="generation-checkbox-retainCovariates">
 	<span>
-		<input class="hover-toolbox" type="checkbox" data-bind="attr:{ id: $data.sourceKey } , checked: $component.getRetainCohortCovariates($data), tooltip: 'Generate with Retain Covariates'" data-placement="right"/>
-	</span>
+		<input class="hover-toolbox" type="checkbox" data-bind="attr:{ id: $data.sourceKey } , checked: retainCovariates, tooltip: 'Generate with Retain Covariates', eventListener: [ 
+			{event: 'mouseover', selector: 'input', callback: $component.addToolTipCovariates },
+			{event: 'mouseout', selector: 'input', callback: $component.removeToolTipCovariates }, 
+			{event: 'mouseup', selector: 'input', callback: $component.handleRetainCovariates }]" data-placement="right"/>	
+</span>
 </script>
 
 <!-- /ko -->

--- a/js/pages/cohort-definitions/cohort-definition-manager.html
+++ b/js/pages/cohort-definitions/cohort-definition-manager.html
@@ -768,6 +768,9 @@
 
 <script type="text/html" id="generation-buttons">
 	<div class="generation-buttons">
+		<span class="generation-span" data-bind="tooltip: 'Save Covariates'">
+			<input type="checkbox" id="generation-checkbox" class="generation-checkbox" data-bind="checked: $component.getRetainCohortCovariates($data)"/>
+		</span>
 		<span data-bind="tooltip: $component.isNew() ? 'You must save the current cohort definition before you can perform generation' : !$component.hasAccessToGenerate(sourceKey) ? 'Not enough permissions to generate' : null" data-placement="left">
 			<span data-bind="tooltip: !$component.canGenerate() ? $component.generateDisabledReason() : null" data-placement="left">
 				<button class="btn btn-sm btn-primary"

--- a/js/pages/cohort-definitions/cohort-definition-manager.js
+++ b/js/pages/cohort-definitions/cohort-definition-manager.js
@@ -610,7 +610,6 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 				data: 'retainCovariates',
 				sortable: false,
 				tooltip: 'Generate with Retain Covariates',
-				className: 'text-center',
 				render: () =>
 				  `<span data-bind="template: {name: 'generation-checkbox-retainCovariates', data: $data }"></span>`
 			},{

--- a/js/pages/cohort-definitions/cohort-definition-manager.js
+++ b/js/pages/cohort-definitions/cohort-definition-manager.js
@@ -604,6 +604,17 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 			}, {
 				title: ko.i18n('cohortDefinitions.cohortDefinitionManager.panels.generationDuration', 'Generation Duration'),
 				data: 'executionDuration'
+			}, {
+				title: ko.i18n('cohortDefinitions.cohortDefinitionManager.panels.retainCovariates', 'Retain Covariates'),
+				data: 'retainCovariate',
+				sortable: false,
+				tooltip: 'Generate with Retain Covariates',
+				render: () =>
+				  `<span data-bind="template: {name: 'generation-checkbox-retainCovariate', data: $data }"></span>`
+			},{
+				sortable: false,
+				className: 'generation-buttons-column',
+				render: () => `<span data-bind="template: { name: 'generation-buttons', data: $data }"></span>`
 			}];
 
 			this.stopping = ko.pureComputed(() => this.cohortDefinitionSourceInfo().reduce((acc, target) => ({...acc, [target.sourceKey]: ko.observable(false)}), {}));
@@ -1316,6 +1327,23 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 
 		async prepareCohortDefinition(cohortDefinitionId, conceptSetId, selectedSourceId, sourceKey, versionNumber) {
 			this.isLoading(true);
+			ko.bindingHandlers.tooltip = {
+				init: function (element, valueAccessor) {
+					const value = ko.utils.unwrapObservable(valueAccessor());
+					$("[aria-label='Retain Covariates']").attr('data-original-title', 'Generate with Retain Covariates').bstooltip({
+						html: true,
+						container:'body',
+					});
+					$(element).attr('data-original-title', value).bstooltip({
+						html: true,
+						container:'body'
+					});
+				},
+				update: function (element, valueAccessor) {
+					const value = ko.utils.unwrapObservable(valueAccessor());
+					$(element).attr('data-original-title', value);
+				}
+			}
 			if(parseInt(cohortDefinitionId) === 0) {
 				this.setNewCohortDefinition();
 			} else if (versionNumber) {
@@ -1424,27 +1452,6 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 				}
 				if (typeof info.retainCohortCovariates !== 'undefined' && info.retainCohortCovariates === true) {
 					info.retainCohortCovariates = false;
-					return false
-				}
-				
-				return info.retainCohortCovariates
-			}
-
-			getRetainCohortCovariates(info) {
-				if(typeof info.retainCohortCovariates === 'undefined' && info.retainCohortCovariates === undefined ) {
-					info.retainCohortCovariates = true;
-
-					return true
-				}
-				
-				if (!typeof info.retainCohortCovariates !== 'undefined' && info.retainCohortCovariates === false) {
-					info.retainCohortCovariates = true;
-
-					return true
-				}
-				if (typeof info.retainCohortCovariates !== 'undefined' && info.retainCohortCovariates === true) {
-					info.retainCohortCovariates = false;
-
 					return false
 				}
 				

--- a/js/pages/cohort-definitions/cohort-definition-manager.js
+++ b/js/pages/cohort-definitions/cohort-definition-manager.js
@@ -584,10 +584,6 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 
 			this.sourcesTableOptions = commonUtils.getTableOptions('S');
 			this.sourcesColumns = [{
-				sortable: false,
-				className: 'generation-buttons-column',
-				render: () => `<span data-bind="template: { name: 'generation-buttons', data: $data }"></span>`
-			}, {
 				title: `<span>${ko.i18n('cohortDefinitions.cohortDefinitionManager.panels.sourceName', 'Source Name')()}</span>`,
 				data: 'name'
 			}, {

--- a/js/pages/cohort-definitions/cohort-definition-manager.js
+++ b/js/pages/cohort-definitions/cohort-definition-manager.js
@@ -609,6 +609,7 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 				data: 'retainCovariate',
 				sortable: false,
 				tooltip: 'Generate with Retain Covariates',
+				className: 'text-center',
 				render: () =>
 				  `<span data-bind="template: {name: 'generation-checkbox-retainCovariate', data: $data }"></span>`
 			},{

--- a/js/pages/cohort-definitions/cohort-definition-manager.js
+++ b/js/pages/cohort-definitions/cohort-definition-manager.js
@@ -1094,7 +1094,7 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 			if (this.selectedSource() && this.selectedSource().sourceId === source.sourceId) {
 				this.toggleCohortReport(null);
 			}
-			cohortDefinitionService.generate(this.currentCohortDefinition().id(), source.sourceKey)
+			cohortDefinitionService.generate(this.currentCohortDefinition().id(), source.sourceKey, source.retainCohortCovariates)
 				.catch(this.authApi.handleAccessDenied)
 				.then(({data}) => {
 					jobDetailsService.createJob(data);
@@ -1410,6 +1410,45 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 
 			getStatusTemplate(item) {
 				return item.status === 'FAILED' ? 'failed-status-tmpl' : 'success-status-tmpl';
+			}
+			
+			getRetainCohortCovariates(info) {
+				if(typeof info.retainCohortCovariates === 'undefined' && info.retainCohortCovariates === undefined ) {
+					info.retainCohortCovariates = true;
+					return true
+				}
+				
+				if (!typeof info.retainCohortCovariates !== 'undefined' && info.retainCohortCovariates === false) {
+					info.retainCohortCovariates = true;
+					return true
+				}
+				if (typeof info.retainCohortCovariates !== 'undefined' && info.retainCohortCovariates === true) {
+					info.retainCohortCovariates = false;
+					return false
+				}
+				
+				return info.retainCohortCovariates
+			}
+
+			getRetainCohortCovariates(info) {
+				if(typeof info.retainCohortCovariates === 'undefined' && info.retainCohortCovariates === undefined ) {
+					info.retainCohortCovariates = true;
+
+					return true
+				}
+				
+				if (!typeof info.retainCohortCovariates !== 'undefined' && info.retainCohortCovariates === false) {
+					info.retainCohortCovariates = true;
+
+					return true
+				}
+				if (typeof info.retainCohortCovariates !== 'undefined' && info.retainCohortCovariates === true) {
+					info.retainCohortCovariates = false;
+
+					return false
+				}
+				
+				return info.retainCohortCovariates
 			}
 
 			showExitMessage(sourceKey) {

--- a/js/services/CohortDefinition.js
+++ b/js/services/CohortDefinition.js
@@ -100,8 +100,8 @@ define(function (require, exports) {
 	}
 
 
-	function generate(cohortDefinitionId, sourceKey) {
-		return httpService.doGet(`${config.webAPIRoot}cohortdefinition/${cohortDefinitionId}/generate/${sourceKey}`);
+	function generate(cohortDefinitionId, sourceKey, retainCohortCovariates) {
+		return httpService.doGet(`${config.webAPIRoot}cohortdefinition/${cohortDefinitionId}/generate/${sourceKey}?retainCohortCovariates=${retainCohortCovariates}`);
 	}
 
 


### PR DESCRIPTION
Addressing https://github.com/OHDSI/WebAPI/issues/2332

When a Cohort is generated there is a possibility to optionally choose so that a cohort_details_<cohort_id> table is recreated in the result schema with some already known attributes from the cohort table and the supplementary ones from the temporary tables which are populated during cohort generation