### PR TITLE
Switch clear-server cache button to clear webapi cache.

### DIFF
--- a/js/services/CacheAPI.js
+++ b/js/services/CacheAPI.js
@@ -1,20 +1,19 @@
-define(function (require, exports) {
-  const config = require('appConfig');
-  const authApi = require('services/AuthAPI');
-  const httpService = require('services/http');
+define(function(require, exports) {
 
-  function clearCache() {
-    return httpService
-      .doPost(config.webAPIRoot + 'cdmresults/clearCache')
-      .then((res) => res.data)
-      .catch((error) => {
-        console.log('Error: ' + error);
-        authApi.handleAccessDenied(error);
-        return Promise.reject(error);
-      });
-  }
+	const config = require('appConfig');
+	const authApi = require('services/AuthAPI');
+	const httpService = require('services/http');
 
-  return {
-    clearCache,
-  };
+	function clearCache() {
+		return httpService.doGet(config.webAPIRoot + 'cache/clear')
+			.then(res => res.data)
+			.catch((error) => {
+				console.log("Error: " + error);
+				authApi.handleAccessDenied(error);
+			});
+	}
+
+	return {
+		clearCache,
+	};
 });


### PR DESCRIPTION
With the introduction of caching in OHDSI/WebAPI#2393, we have a middle-tier cache that contains auth info and entity list caches.  This PR reverts a change that had the clear server cache button refresh the CDM caches, and instead will clear the webAPI cache.

You can still clear individual CDM caches using the individual 'refresh cache' buttons in the configuration ui.
