### PR TITLE
fix: use _ alias for lodash in config module

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -4,7 +4,7 @@ define([
 	'optional!config-local',
 	'optional!config-gis',
 	'lodash',
-], function (app, termsAndConditions, localConfig, gisConfig, lodash) {
+], function (app, termsAndConditions, localConfig, gisConfig, _) {
 
 	if (JSON.stringify(localConfig) == JSON.stringify({})) {
 		console.warn('Local configuration not found.  Using default values. To use a local configuration and suppress 404 errors, create a file called config-local.js under the /js directory');


### PR DESCRIPTION
Fix the AMD factory to inject Lodash as _, matching the symbol the module uses
  - Prevents _.mergeWith/_.isArray from falling back to a global lodash object and throwing when it’s
  unavailable
  - No functional behavior change beyond ensuring the config merge logic consistently works in environments
  without a global _